### PR TITLE
Fix repo .gitignore file matching

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -55,7 +55,7 @@ module ModuleSync
     # https://github.com/schacon/ruby-git/issues/130
     def self.untracked_unignored_files(repo)
       ignored = File.open("#{repo.dir.path}/.gitignore").read.split
-      repo.status.untracked.keep_if{|f,_| !ignored.any?{|i| f.match(/#{i}/)}}
+      repo.status.untracked.keep_if{|f,_| !ignored.any?{|i| File.fnmatch(i, f)}}
     end
 
     def self.update_noop(name, branch)


### PR DESCRIPTION
Without this patch, the untracked_unignored_files method tries to match
files based on regex when .gitignore generally specifies matches with
globs. This causes an error if a user adds a .gitignore to a module
with an entry that is a glob rather than an exact match. This patch
fixes the problem by using File.fnmatch instead of the string match
method to compare file names.

Fixes: #25 
