### PR TITLE
Add a --filter option to restrict which repositores are synchronized

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -30,12 +30,13 @@ module ModuleSync
     local_files.map { |file| file.sub(/#{path}/, '') }
   end
 
-  def self.managed_modules(path)
+  def self.managed_modules(path, filter)
     managed_modules = Util.parse_config(path)
     if managed_modules.empty?
       puts "No modules found at #{path}. Check that you specified the right configs directory containing managed_modules.yml."
       exit
     end
+    managed_modules.select! { |m| m =~ Regexp.new(filter) } unless filter.nil?
     managed_modules
   end
 
@@ -50,7 +51,7 @@ module ModuleSync
       local_files = self.local_files(path)
       module_files = self.module_files(local_files, path)
 
-      managed_modules = self.managed_modules("#{options[:configs]}/managed_modules.yml")
+      managed_modules = self.managed_modules("#{options[:configs]}/managed_modules.yml", options[:filter])
 
       managed_modules.each do |puppet_module|
         puts "Syncing #{puppet_module}"

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -35,7 +35,7 @@ module ModuleSync
       @options.merge!(Hash.transform_keys_to_symbols(Util.parse_config(MODULESYNC_CONF_FILE)))
       @options[:command] = args[0] if commands_available.include?(args[0])
       opt_parser = OptionParser.new do |opts|
-        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--noop] [-n <namespace>] [-b <branch>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
+        opts.banner = "Usage: msync update [-m <commit message>] [-c <directory> ] [--noop] [-n <namespace>] [-b <branch>] [-f <filter>] | hook activate|deactivate [-c <directory> ] [-n <namespace>] [-b <branch>]"
         opts.on('-m', '--message <msg>',
                 'Commit message to apply to updated modules') do |msg|
           @options[:message] = msg
@@ -51,6 +51,10 @@ module ModuleSync
         opts.on('-b', '--branch <branch>',
                 'Branch name to make the changes in. Defaults to "master"') do |branch|
           @options[:branch] = branch
+        end
+        opts.on('-f', '--filter <filter>',
+                'A regular expression to filter repositories to update.') do |filter|
+          @options[:filter] = filter
         end
         opts.on('--noop',
                 'No-op mode') do |msg|


### PR DESCRIPTION
This allows to synchronize only a few repositories using a regexp:

```
msync update -f augeas
```

```
msync update -f puppet-a..o
```
