### PR TITLE
Make it work without Github

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -53,9 +53,15 @@ module ModuleSync
 
       managed_modules = self.managed_modules("#{options[:configs]}/managed_modules.yml", options[:filter])
 
-      managed_modules.each do |puppet_module|
+      # managed_modules is either an array or a hash
+      managed_modules.each do |puppet_module, opts|
         puts "Syncing #{puppet_module}"
-        Git.pull(options[:git_user], options[:git_provider_address], options[:namespace], puppet_module)
+        if options[:git_base]
+          git_base = options[:git_base]
+        else
+          git_base = "#{options[:git_user]}@#{options[:git_provider_address]}:#{options[:namespace]}"
+        end
+        Git.pull(git_base, puppet_module, options[:branch], opts || {})
         module_configs = Util.parse_config("#{PROJ_ROOT}/#{puppet_module}/#{MODULE_CONF_FILE}")
         files_to_manage = module_files | defaults.keys | module_configs.keys
         files_to_delete = []


### PR DESCRIPTION
This PR intends to make modulesync more generic. It changes the following:
- Allow to set `git_base` in `modulesync.yml` to set a Git base instead of `git_user`, `git_provider_address` and `namespace`. This allows for more generic URI.
- Allow parameters for modules in `managed_modules.yml`. In order to do that, `managed_modules.yml` can now be either an array (compatible mode) or a hash with options. One option is passed so far (`:remote`), which allows to synchronize modules with completely different git bases (on different Puppet masters for example). E.g.:

``` yaml

---
foo:
  :remote: 'git@puppetmaster1.example.com:/etc/puppet/modules/foo'
bar:
  :remote: 'git@puppetmaster2.example.com:/srv/puppet/bar'
```
- Fix support for custom branch, which wasn't working since `Git#pull` and `Git#push` were called without this parameter
