### PR TITLE
Pull git_base into a CLI param

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -13,7 +13,6 @@ module ModuleSync
   def self.config_defaults
     {
       :project_root         => 'modules/',
-      :git_base             => 'git@github.com:',
       :managed_modules_conf => 'managed_modules.yml',
       :configs              => '.',
       :tag_pattern          => '%s',

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -28,6 +28,7 @@ module ModuleSync
       include Constants
 
       class_option :project_root, :aliases => '-c', :desc => 'Path used by git to clone modules into. Defaults to "modules"', :default => 'modules'
+      class_option :git_base, :desc => 'Specify the base part of a git URL to pull from', :default => 'git@github.com:'
       class_option :namespace, :aliases => '-n', :desc => 'Remote github namespace (user or organization) to clone from and push to. Defaults to puppetlabs', :default => 'puppetlabs'
       class_option :filter, :aliases => '-f', :desc => 'A regular expression to filter repositories to update.'
       class_option :branch, :aliases => '-b', :desc => 'Branch name to make the changes in. Defaults to master.', :default => 'master'


### PR DESCRIPTION
This allows flexible overriding of the git base, e.g. when a CI job needs
to use github's https access, when no SSH credentials are available.