### PR TITLE
Expose config variables to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,16 @@ current date, bumped (minor) version, and commit message.
 If `CHANGELOG.md` is absent in the repository, nothing will happen.
 
 
+#### Defining templates
+
+As commented, files within moduleroot directory can be flat files or ERB templates. These files have direct access to @configs hash, which gets values from config_defaults.yml file and from the module being processed:
+
+```
+<%= @configs[:git_base] %>
+<%= @configs[:namespace] %>
+<%= @configs[:puppet_module] %>
+```
+
 The Templates
 -------------
 

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -93,8 +93,9 @@ module ModuleSync
       puts "Syncing #{puppet_module}"
       namespace, module_name = self.module_name(puppet_module, options[:namespace])
       unless options[:offline]
-        git_base = "#{options[:git_base]}#{namespace}"
-        Git.pull(git_base, module_name, options[:branch], options[:project_root], opts || {})
+        git_base = "#{options[:git_base]}"
+        git_uri = "#{git_base}#{namespace}"
+        Git.pull(git_uri, module_name, options[:branch], options[:project_root], opts || {})
       end
       module_configs = Util.parse_config("#{options[:project_root]}/#{module_name}/#{MODULE_CONF_FILE}")
       global_defaults = defaults[GLOBAL_DEFAULTS_KEY] || {}
@@ -104,6 +105,8 @@ module ModuleSync
       files_to_manage.each do |filename|
         configs = module_configs(filename, global_defaults, defaults, module_defaults, module_configs)
         configs[:puppet_module] = module_name
+        configs[:git_base] = git_base
+        configs[:namespace] = namespace
         if unmanaged?(filename, global_defaults, defaults, module_defaults, module_configs)
           puts "Not managing #{filename} in #{module_name}"
           unmanaged_files << filename


### PR DESCRIPTION
We needed a way to get config variables like git_base and namespace in template files so we can generate, as an example, better README files.

This change adds those variables to @configs hash. It also add some documentation and a new test.