### PR TITLE
(maint) fixes delete issue

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -170,6 +170,28 @@ Feature: update
       """
     And the exit status should be 0
 
+  Scenario: Setting a non-existent file to deleted
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      doesntexist_file:
+        delete: true
+      """
+    And a directory named "moduleroot"
+    When I run `msync update -m 'deletes a file that doesnt exist!' -f puppet-test`
+    And the exit status should be 0
+
   Scenario: Setting a directory to unmanaged
     Given a file named "managed_modules.yml" with:
       """

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -103,10 +103,8 @@ module ModuleSync
       repo.branch(options[:branch]).checkout
       files.each do |file|
         if repo.status.deleted.include?(file)
-          if File.exist?(file)
-            repo.remove(file)
-          end
-        else
+          repo.remove(file)
+        elsif File.exist?(file)
           repo.add(file)
         end
       end

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -103,7 +103,9 @@ module ModuleSync
       repo.branch(options[:branch]).checkout
       files.each do |file|
         if repo.status.deleted.include?(file)
-          repo.remove(file)
+          if File.exist?(file)
+            repo.remove(file)
+          end
         else
           repo.add(file)
         end


### PR DESCRIPTION
Only add files to a commit that exist locally. 

Scenario: A file has already been removed from one or more managed modules and is also added to the modulesync_config as a file to delete. When modulesync is run, an error is thrown saying i've "removed" this file but I can't add it to the commit because it didn't exist to begin with.