### PR TITLE
allow .erb extension

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -589,3 +589,108 @@ Feature: update
       """
       echo 'https://github.com/maestrodev'
       """
+
+  Scenario: Using .erb extension template
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      README.md.erb:
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/README.md.erb" with:
+      """
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      """
+    When I run `msync update --noop`
+    Then the exit status should be 0
+    And the output should match:
+      """
+      Files changed:
+      +diff --git a/README.md b/README.md
+      """
+    Given I run `cat modules/puppet-test/README.md`
+    Then the output should contain:
+      """
+      echo 'https://github.com/maestrodev'
+      """
+
+  Scenario: Using .erb extension template but settings ommit .erb
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      README.md:
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/README.md.erb" with:
+      """
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      """
+    When I run `msync update --noop`
+    Then the exit status should be 0
+    And the output should match:
+      """
+      Files changed:
+      +diff --git a/README.md b/README.md
+      """
+    Given I run `cat modules/puppet-test/README.md`
+    Then the output should contain:
+      """
+      echo 'https://github.com/maestrodev'
+      """
+
+  Scenario: Using non-.erb extension template but settings use .erb
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      README.md.erb:
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/README.md" with:
+      """
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      """
+    When I run `msync update --noop`
+    Then the exit status should be 0
+    And the output should match:
+      """
+      Files changed:
+      +diff --git a/README.md b/README.md
+      """
+    Given I run `cat modules/puppet-test/README.md`
+    Then the output should contain:
+      """
+      echo 'https://github.com/maestrodev'
+      """

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -10,8 +10,14 @@ module ModuleSync
     end
 
     def self.build(from_erb_template)
-      erb_obj = ERB.new(File.read(from_erb_template), nil, '-')
-      erb_obj.filename = from_erb_template.chomp('.erb')
+      from_erb_template = from_erb_template.chomp('.erb')
+      template_file = if File.exist?("#{from_erb_template}.erb")
+                        "#{from_erb_template}.erb"
+                      else
+                        from_erb_template
+                      end
+      erb_obj = ERB.new(File.read(template_file), nil, '-')
+      erb_obj.filename = from_erb_template
       erb_obj.def_method(ForgeModuleFile, 'render()')
       erb_obj
     end
@@ -27,7 +33,7 @@ module ModuleSync
     def self.sync(template, to_file)
       path = to_file.rpartition('/').first
       FileUtils.mkdir_p(path) unless path.empty?
-      File.open(to_file, 'w') do |file|
+      File.open(to_file.chomp('.erb'), 'w') do |file|
         file.write(template)
       end
     end

--- a/lib/modulesync/settings.rb
+++ b/lib/modulesync/settings.rb
@@ -12,8 +12,16 @@ module ModuleSync
       @additional_settings = additional_settings
     end
 
+    def lookup_config(hash, filename)
+      hash[filename] || {}
+    end
+
     def build_file_configs(filename)
-      global_defaults.merge(defaults[filename] || {}).merge(module_defaults).merge(module_configs[filename] || {}).merge(additional_settings)
+      file_def = lookup_config(defaults, filename)
+      file_md  = lookup_config(module_defaults, filename)
+      file_mc  = lookup_config(module_configs, filename)
+
+      global_defaults.merge(file_def).merge(file_md).merge(file_mc).merge(additional_settings)
     end
 
     def managed?(filename)


### PR DESCRIPTION
This change allows for files to be named with or without .erb extension
This also addresses when there are numerous .rubocop.yml files which
may error if containing erb code.

reference: https://github.com/voxpupuli/modulesync_config/issues/295