### PR TITLE
Fix globals symbol

### DIFF
--- a/lib/modulesync/settings.rb
+++ b/lib/modulesync/settings.rb
@@ -27,14 +27,14 @@ module ModuleSync
     # given a list of existing files in the repo, return everything that we might want to act on
     def managed_files(file_list)
       (file_list | defaults.keys | module_configs.keys).select do |f|
-        managed?(f) && (f != ModuleSync::GLOBAL_DEFAULTS_KEY)
+        (f != ModuleSync::GLOBAL_DEFAULTS_KEY) && managed?(f)
       end
     end
 
     # returns a list of files that should not be touched
     def unmanaged_files(file_list)
       (file_list | defaults.keys | module_configs.keys).select do |f|
-        !managed?(f) && (f != ModuleSync::GLOBAL_DEFAULTS_KEY)
+        (f != ModuleSync::GLOBAL_DEFAULTS_KEY) && !managed?(f)
       end
     end
   end

--- a/spec/unit/modulesync/settings_spec.rb
+++ b/spec/unit/modulesync/settings_spec.rb
@@ -7,6 +7,7 @@ describe ModuleSync::Settings do
       {},
       {},
       { 'Rakefile' => { 'unmanaged' => true },
+        :global => { 'global' => 'value' },
         'Gemfile' => { 'key' => 'value' }, },
       {}
     )


### PR DESCRIPTION
Without this commit, the globals entry defaults to a symbol `:global`
and this is initially passed through to `managed?()` which then calls
Pathname. Pathname expects a string so this fails.

With this patch we first check if the key is the default globals key
before passing it through, thus allowing globals to work correctly.