### PR TITLE
Handle rendering exception

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -62,6 +62,34 @@ Feature: update
     When I run `msync update --noop`
     Then the exit status should be 1
 
+  Scenario: Using skip_broken option with invalid files
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      test:
+        name: aruba
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/test" with:
+      """
+      <% @configs.each do |c| -%>
+        <%= c['name'] %>
+      <% end %>
+      """
+    When I run `msync update --noop -s`
+    Then the exit status should be 0
+
   Scenario: Modifying an existing file
     Given a file named "managed_modules.yml" with:
       """

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -98,32 +98,38 @@ module ModuleSync
 
     # managed_modules is either an array or a hash
     managed_modules.each do |puppet_module, module_options|
-      puts "Syncing #{puppet_module}"
-      namespace, module_name = self.module_name(puppet_module, options[:namespace])
-      unless options[:offline]
-        git_base = options[:git_base]
-        git_uri = "#{git_base}#{namespace}"
-        Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
-      end
-      module_configs = Util.parse_config("#{options[:project_root]}/#{module_name}/#{MODULE_CONF_FILE}")
-      settings = Settings.new(defaults[GLOBAL_DEFAULTS_KEY] || {},
-                              defaults,
-                              module_configs[GLOBAL_DEFAULTS_KEY] || {},
-                              module_configs,
-                              :puppet_module => module_name,
-                              :git_base => git_base,
-                              :namespace => namespace)
-      settings.unmanaged_files(module_files).each do |filename|
-        puts "Not managing #{filename} in #{module_name}"
-      end
+      begin
+        puts "Syncing #{puppet_module}"
+        namespace, module_name = self.module_name(puppet_module, options[:namespace])
+        unless options[:offline]
+          git_base = options[:git_base]
+          git_uri = "#{git_base}#{namespace}"
+          Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
+        end
+        module_configs = Util.parse_config("#{options[:project_root]}/#{module_name}/#{MODULE_CONF_FILE}")
+        settings = Settings.new(defaults[GLOBAL_DEFAULTS_KEY] || {},
+                                defaults,
+                                module_configs[GLOBAL_DEFAULTS_KEY] || {},
+                                module_configs,
+                                :puppet_module => module_name,
+                                :git_base => git_base,
+                                :namespace => namespace)
+        settings.unmanaged_files(module_files).each do |filename|
+          puts "Not managing #{filename} in #{module_name}"
+        end
 
-      files_to_manage = settings.managed_files(module_files)
-      files_to_manage.each { |filename| manage_file(filename, settings, options) }
+        files_to_manage = settings.managed_files(module_files)
+        files_to_manage.each { |filename| manage_file(filename, settings, options) }
 
-      if options[:noop]
-        Git.update_noop(module_name, options)
-      elsif !options[:offline]
-        Git.update(module_name, files_to_manage, options)
+        if options[:noop]
+          Git.update_noop(module_name, options)
+        elsif !options[:offline]
+          Git.update(module_name, files_to_manage, options)
+        end
+      rescue
+        STDERR.puts "Error while updating #{puppet_module}"
+        raise unless options[:skip_broken]
+        puts "Skipping #{puppet_module} as update process failed"
       end
     end
   end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -86,6 +86,36 @@ module ModuleSync
     end
   end
 
+  def self.manage_module(puppet_module, module_files, module_options, defaults, options)
+    puts "Syncing #{puppet_module}"
+    namespace, module_name = self.module_name(puppet_module, options[:namespace])
+    unless options[:offline]
+      git_base = options[:git_base]
+      git_uri = "#{git_base}#{namespace}"
+      Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
+    end
+    module_configs = Util.parse_config("#{options[:project_root]}/#{module_name}/#{MODULE_CONF_FILE}")
+    settings = Settings.new(defaults[GLOBAL_DEFAULTS_KEY] || {},
+                            defaults,
+                            module_configs[GLOBAL_DEFAULTS_KEY] || {},
+                            module_configs,
+                            :puppet_module => module_name,
+                            :git_base => git_base,
+                            :namespace => namespace)
+    settings.unmanaged_files(module_files).each do |filename|
+      puts "Not managing #{filename} in #{module_name}"
+    end
+
+    files_to_manage = settings.managed_files(module_files)
+    files_to_manage.each { |filename| manage_file(filename, settings, options) }
+
+    if options[:noop]
+      Git.update_noop(module_name, options)
+    elsif !options[:offline]
+      Git.update(module_name, files_to_manage, options)
+    end
+  end
+
   def self.update(options)
     options = config_defaults.merge(options)
     defaults = Util.parse_config("#{options[:configs]}/#{CONF_FILE}")
@@ -99,33 +129,7 @@ module ModuleSync
     # managed_modules is either an array or a hash
     managed_modules.each do |puppet_module, module_options|
       begin
-        puts "Syncing #{puppet_module}"
-        namespace, module_name = self.module_name(puppet_module, options[:namespace])
-        unless options[:offline]
-          git_base = options[:git_base]
-          git_uri = "#{git_base}#{namespace}"
-          Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
-        end
-        module_configs = Util.parse_config("#{options[:project_root]}/#{module_name}/#{MODULE_CONF_FILE}")
-        settings = Settings.new(defaults[GLOBAL_DEFAULTS_KEY] || {},
-                                defaults,
-                                module_configs[GLOBAL_DEFAULTS_KEY] || {},
-                                module_configs,
-                                :puppet_module => module_name,
-                                :git_base => git_base,
-                                :namespace => namespace)
-        settings.unmanaged_files(module_files).each do |filename|
-          puts "Not managing #{filename} in #{module_name}"
-        end
-
-        files_to_manage = settings.managed_files(module_files)
-        files_to_manage.each { |filename| manage_file(filename, settings, options) }
-
-        if options[:noop]
-          Git.update_noop(module_name, options)
-        elsif !options[:offline]
-          Git.update(module_name, files_to_manage, options)
-        end
+        manage_module(puppet_module, module_files, module_options, defaults, options)
       rescue
         STDERR.puts "Error while updating #{puppet_module}"
         raise unless options[:skip_broken]

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -38,6 +38,7 @@ module ModuleSync
       option :message, :aliases => '-m', :desc => 'Commit message to apply to updated modules. Required unless running in noop mode.'
       option :configs, :aliases => '-c', :desc => 'The local directory or remote repository to define the list of managed modules, the file templates, and the default values for template variables.'
       option :remote_branch, :aliases => '-r', :desc => 'Remote branch name to push the changes to. Defaults to the branch name.'
+      option :skip_broken, :type => :boolean, :aliases => '-s', :desc => 'Process remaining modules if an error is found', :default => false
       option :amend, :type => :boolean, :desc => 'Amend previous commit', :default => false
       option :force, :type => :boolean, :desc => 'Force push amended commit', :default => false
       option :noop, :type => :boolean, :desc => 'No-op mode', :default => false


### PR DESCRIPTION
If there was a rendering problem while processing a module, the
whole update process was stopped. Now the process will continue for
the remaining modules. Fix issue #97.