### PR TITLE
Fix Travis CI deployment version to match matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ deploy:
     secure: "NGKJHr9ba/Jmy/n9QrTVnFyMFdkjkv2A3JvKvtJHSa1T795Atak2A/cyA0LF5sBib8NDEgw49Om53g5ZvdTxGKkw5OJuPouwvJ9gFQkv+gDf43tjdAa7oMSLixKVp+dxLvpUC+pBjEPR3gM2qs2mBwax/YWCIreI1HXfXOzrRHA="
   gem: modulesync
   on:
-    rvm: 2.4
+    rvm: 2.4.0
     tags: true
     all_branches: true
     repo: voxpupuli/modulesync


### PR DESCRIPTION
Prevented 0.7.0 from being released (https://travis-ci.org/voxpupuli/modulesync/jobs/201089762).