### PR TITLE
Change git required version

### DIFF
--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_runtime_dependency 'git', '~>1.2'
+  spec.add_runtime_dependency 'git', '~>1.3'
   spec.add_runtime_dependency 'puppet-blacksmith', '~>3.0'
   spec.add_runtime_dependency 'thor'
 end


### PR DESCRIPTION
The new diff functionality in git.rb requires a newer rubygem-git version.