### PR TITLE
Pass filename through to ERB and ignore .erb template extensions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,7 @@ Style/HashSyntax:
 # dealbreaker:
 Style/TrailingCommaInLiteral:
   Enabled: false
+
+# would require external library
+Style/IndentHeredoc:
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -18,4 +18,4 @@ Cucumber::Rake::Task.new do |t|
   t.cucumber_opts << '--format pretty'
 end
 
-task :test => [:clean, :spec, :cucumber, :rubocop]
+task :test => %i[clean spec cucumber rubocop]

--- a/features/update.feature
+++ b/features/update.feature
@@ -607,7 +607,7 @@ Feature: update
     Given I run `cat modules/puppet-lib-file_concat/.git/config`
     Then the output should contain "url = https://github.com/electrical/puppet-lib-file_concat.git"
 
-  Scenario: Modifying an existing file with values expoxed by the module
+  Scenario: Modifying an existing file with values exposed by the module
     Given a file named "managed_modules.yml" with:
       """
       ---
@@ -623,11 +623,12 @@ Feature: update
       """
       ---
       README.md:
+        key: value
       """
     And a directory named "moduleroot"
     And a file named "moduleroot/README.md" with:
       """
-      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>/<%= @configs['key'] %>'
       """
     When I run `msync update --noop`
     Then the exit status should be 0
@@ -639,7 +640,7 @@ Feature: update
     Given I run `cat modules/puppet-test/README.md`
     Then the output should contain:
       """
-      echo 'https://github.com/maestrodev'
+      echo 'https://github.com/maestrodev/value'
       """
 
   Scenario: Using .erb extension template
@@ -658,11 +659,12 @@ Feature: update
       """
       ---
       README.md.erb:
+        key: value
       """
     And a directory named "moduleroot"
     And a file named "moduleroot/README.md.erb" with:
       """
-      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>/<%= @configs['key'] %>'
       """
     When I run `msync update --noop`
     Then the exit status should be 0
@@ -674,10 +676,10 @@ Feature: update
     Given I run `cat modules/puppet-test/README.md`
     Then the output should contain:
       """
-      echo 'https://github.com/maestrodev'
+      echo 'https://github.com/maestrodev/value'
       """
 
-  Scenario: Using .erb extension template but settings ommit .erb
+  Scenario: Using .erb extension template but settings omit .erb
     Given a file named "managed_modules.yml" with:
       """
       ---
@@ -693,11 +695,12 @@ Feature: update
       """
       ---
       README.md:
+        key: value
       """
     And a directory named "moduleroot"
     And a file named "moduleroot/README.md.erb" with:
       """
-      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>/<%= @configs['key'] %>'
       """
     When I run `msync update --noop`
     Then the exit status should be 0
@@ -709,7 +712,7 @@ Feature: update
     Given I run `cat modules/puppet-test/README.md`
     Then the output should contain:
       """
-      echo 'https://github.com/maestrodev'
+      echo 'https://github.com/maestrodev/value'
       """
 
   Scenario: Using non-.erb extension template but settings use .erb
@@ -728,11 +731,12 @@ Feature: update
       """
       ---
       README.md.erb:
+        key: value
       """
     And a directory named "moduleroot"
     And a file named "moduleroot/README.md" with:
       """
-      echo '<%= @configs[:git_base] + @configs[:namespace] %>'
+      echo '<%= @configs[:git_base] + @configs[:namespace] %>/<%= @configs['key'] %>'
       """
     When I run `msync update --noop`
     Then the exit status should be 0
@@ -744,7 +748,7 @@ Feature: update
     Given I run `cat modules/puppet-test/README.md`
     Then the output should contain:
       """
-      echo 'https://github.com/maestrodev'
+      echo 'https://github.com/maestrodev/value'
       """
 
   Scenario: Running the same update twice and pushing to a remote branch

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -49,7 +49,7 @@ module ModuleSync
       exit
     end
     managed_modules.select! { |m| m =~ Regexp.new(filter) } unless filter.nil?
-    managed_modules.select! { |m| m !~ Regexp.new(negative_filter) } unless negative_filter.nil?
+    managed_modules.reject! { |m| m =~ Regexp.new(negative_filter) } unless negative_filter.nil?
     managed_modules
   end
 
@@ -89,7 +89,7 @@ module ModuleSync
 
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
     puts "Syncing #{puppet_module}"
-    namespace, module_name = self.module_name(puppet_module, options[:namespace])
+    namespace, module_name = module_name(puppet_module, options[:namespace])
     unless options[:offline]
       git_base = options[:git_base]
       git_uri = "#{git_base}#{namespace}"

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -147,7 +147,7 @@ module ModuleSync
     def self.untracked_unignored_files(repo)
       ignore_path = "#{repo.dir.path}/.gitignore"
       ignored = File.exist?(ignore_path) ? File.open(ignore_path).read.split : []
-      repo.status.untracked.keep_if { |f, _| !ignored.any? { |i| File.fnmatch(i, f) } }
+      repo.status.untracked.keep_if { |f, _| ignored.none? { |i| File.fnmatch(i, f) } }
     end
 
     def self.update_noop(name, options)

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -18,7 +18,7 @@ module ModuleSync
                       end
       erb_obj = ERB.new(File.read(template_file), nil, '-')
       erb_obj.filename = from_erb_template
-      erb_obj.def_method(ForgeModuleFile, 'render()')
+      erb_obj.def_method(ForgeModuleFile, 'render()', template_file)
       erb_obj
     end
 

--- a/lib/modulesync/settings.rb
+++ b/lib/modulesync/settings.rb
@@ -13,7 +13,7 @@ module ModuleSync
     end
 
     def lookup_config(hash, filename)
-      hash[filename] || {}
+      hash[filename.chomp('.erb')] || hash[filename] || {}
     end
 
     def build_file_configs(filename)

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/spec/unit/modulesync/settings_spec.rb
+++ b/spec/unit/modulesync/settings_spec.rb
@@ -19,7 +19,7 @@ describe ModuleSync::Settings do
   it { expect(subject.managed?('Gemfile')).to eq true }
   it { expect(subject.managed?('Gemfile/foo')).to eq true }
   it { expect(subject.managed_files([])).to eq ['Gemfile'] }
-  it { expect(subject.managed_files(%w(Rakefile Gemfile other_file))).to eq %w(Gemfile other_file) }
+  it { expect(subject.managed_files(%w[Rakefile Gemfile other_file])).to eq %w[Gemfile other_file] }
   it { expect(subject.unmanaged_files([])).to eq ['Rakefile'] }
-  it { expect(subject.unmanaged_files(%w(Rakefile Gemfile other_file))).to eq ['Rakefile'] }
+  it { expect(subject.unmanaged_files(%w[Rakefile Gemfile other_file])).to eq ['Rakefile'] }
 end


### PR DESCRIPTION
See https://github.com/ruby/ruby/blob/524fb0138b773f2ed01441abbcffeda0271175c5/lib/erb.rb#L916 for details.

This causes stack traces from ERB failures to point to the correct template.