### PR TITLE
(maint) Preserve original line endings in a file

### DIFF
--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -33,7 +33,7 @@ module ModuleSync
     def self.sync(template, target_name)
       path = target_name.rpartition('/').first
       FileUtils.mkdir_p(path) unless path.empty?
-      File.open(target_name, 'w') do |file|
+      File.open(target_name, 'wb:UTF-8') do |file|
         file.write(template)
       end
     end


### PR DESCRIPTION
Previously when rendering a file the line endings would be converted by ruby
to the OS specific style e.g. CRLF on Windows.  However as many modules are
cross platform it is important to preserve the line ending style from the
original moduleroot file e.g. a .BAT file is for windows and should always use
CRLF, whether it's on a Linux of Windows system.  This commit changes the file
opening mode to use binary (which stops the line ending conversion) and forces
all file encoding to UTF-8 which is the default already.