### PR TITLE
Using repo.branch.name always returns master, use repo.current_branch…

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -19,7 +19,7 @@ module ModuleSync
     end
 
     def self.switch_branch(repo, branch)
-      return if repo.branch.name == branch
+      return if repo.current_branch == branch
 
       if local_branch_exists?(repo, branch)
         puts "Switching to branch #{branch}"


### PR DESCRIPTION
… for the guard clause instead so ModuleSync::Git.switch_branch can actually switch to the master branch when it is not the current branch.

Fixes #129 