### PR TITLE
Close .gitignore filehandle.

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -146,7 +146,7 @@ module ModuleSync
     # https://github.com/schacon/ruby-git/issues/130
     def self.untracked_unignored_files(repo)
       ignore_path = "#{repo.dir.path}/.gitignore"
-      ignored = File.exist?(ignore_path) ? File.open(ignore_path).read.split : []
+      ignored = File.exist?(ignore_path) ? File.read(ignore_path).split : []
       repo.status.untracked.keep_if { |f, _| ignored.none? { |i| File.fnmatch(i, f) } }
     end
 


### PR DESCRIPTION
I'm using Octokit.rb to do some discovery about some of my Puppet control repositories.  Part of that involves running ModuleSync across every branch in a control repo -- so basically running `ModuleSync.update` in a loop for each branch in a repository.  The `.gitignore` file is different across a couple branches in the same repo.  I noticed that when switching branches that the `.gitignore` file is shown as having been modified which eventually causes an exception when ModuleSync tries to do a `git reset --hard`.  I finally figured out, probably with some good clues via StackOverflow, that this was caused by the file handle not being explicitly closed for `.gitignore`.  Changing the reading of `.gitignore` to use a block, which implicitly closes the FH, has resolved my issue so I figured I would share it.