### PR TITLE
Remove hard coding of managed_modules.yml which means that options pa…

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -43,10 +43,10 @@ module ModuleSync
     local_files.map { |file| file.sub(/#{path}/, '') }
   end
 
-  def self.managed_modules(path, filter, negative_filter)
-    managed_modules = Util.parse_config(path)
+  def self.managed_modules(config_file, filter, negative_filter)
+    managed_modules = Util.parse_config(config_file)
     if managed_modules.empty?
-      puts "No modules found at #{path}. Check that you specified the right configs directory containing managed_modules.yml."
+      puts "No modules found in #{config_file}. Check that you specified the right :configs directory and :managed_modules_conf file."
       exit
     end
     managed_modules.select! { |m| m =~ Regexp.new(filter) } unless filter.nil?
@@ -126,7 +126,7 @@ module ModuleSync
     local_files = self.local_files(path)
     module_files = self.module_files(local_files, path)
 
-    managed_modules = self.managed_modules("#{options[:configs]}/managed_modules.yml", options[:filter], options[:negative_filter])
+    managed_modules = self.managed_modules("#{options[:configs]}/#{options[:managed_modules_conf]}", options[:filter], options[:negative_filter])
 
     # managed_modules is either an array or a hash
     managed_modules.each do |puppet_module, module_options|

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe ModuleSync do
+  context '::update' do
+    it 'loads the managed modules from the specified :managed_modules_conf' do
+      allow(ModuleSync).to receive(:local_files).and_return([])
+      allow(ModuleSync::Util).to receive(:parse_config).with('./config_defaults.yml').and_return({})
+      expect(ModuleSync).to receive(:managed_modules).with('./test_file.yml', nil, nil).and_return([])
+
+      options = { managed_modules_conf: 'test_file.yml' }
+      ModuleSync.update(options)
+    end
+  end
+end


### PR DESCRIPTION
…ssed to ModuleSync.update can override the filename.  Also improve parameter/variable name and error message in ModuleSync.managed_modules.

**Explanation of why I need/want this:**
I have a use case where I need to do multiple ModuleSync runs concurrently and they may end up running in the same directory on the same machine.  I'm able to override almost everything to make this possible except `:managed_modules_conf` is useless because `managed_modules.yml` is currently hardcoded in `ModuleSync.update`.