### PR TITLE
Do not update gems before_install on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 language: ruby
 cache: bundler
 dist: trusty
-before_install:
-  - gem update --system
-  - gem install bundler
 script: 'bundle exec rake test'
 rvm:
   - 2.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
+
+gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'


### PR DESCRIPTION
This breaks bundler on various Ruby versions.