### PR TITLE
Closes #132. Add new option to produce a failure exit code on warning…

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -258,6 +258,34 @@ Feature: update
     When I run `msync update --noop -s`
     Then the exit status should be 0
 
+  Scenario: Using skip_broken and fail_on_warnings options with invalid files
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      test:
+        name: aruba
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/test.erb" with:
+      """
+      <% @configs.each do |c| -%>
+        <%= c['name'] %>
+      <% end %>
+      """
+    When I run `msync update --noop --skip_broken --fail_on_warnings`
+    Then the exit status should be 1
+
   Scenario: Modifying an existing file
     Given a file named "managed_modules.yml" with:
       """

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -128,6 +128,7 @@ module ModuleSync
 
     managed_modules = self.managed_modules("#{options[:configs]}/#{options[:managed_modules_conf]}", options[:filter], options[:negative_filter])
 
+    errors = false
     # managed_modules is either an array or a hash
     managed_modules.each do |puppet_module, module_options|
       begin
@@ -135,8 +136,10 @@ module ModuleSync
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
         STDERR.puts "Error while updating #{puppet_module}"
         raise unless options[:skip_broken]
+        errors = true
         puts "Skipping #{puppet_module} as update process failed"
       end
     end
+    exit 1 if errors && options[:fail_on_warnings]
   end
 end

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -106,6 +106,11 @@ module ModuleSync
       option :pre_commit_script,
              :desc => 'A script to be run before commiting',
              :default => CLI.defaults[:pre_commit_script]
+      option :fail_on_warnings,
+             :type => :boolean,
+             :aliases => '-F',
+             :desc => 'Produce a failure exit code when there are warnings (only has effect when --skip_broken is enabled)',
+             :default => false
 
       def update
         config = { :command => 'update' }.merge(options)


### PR DESCRIPTION
…s.  Only useful when using --skip_broken option to process all modules but needing feedback that problems were encountered.