### PR TITLE
Fixes #140. Reraise exception rather than exit so we can rescue a der…

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -34,6 +34,32 @@ Feature: update
     Given I run `cat modules/puppet-test/test`
     Then the output should contain "aruba"
 
+  Scenario: Using skip_broken option and adding a new file to repo without write access
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: 'git@github.com:'
+      """
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      test:
+        name: aruba
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/test.erb" with:
+      """
+      <%= @configs['name'] %>
+      """
+    When I run `msync update -s -m "Add test"`
+    Then the exit status should be 0
+
   Scenario: Adding a new file to repo without write access
     Given a file named "managed_modules.yml" with:
       """
@@ -44,7 +70,7 @@ Feature: update
       """
       ---
         namespace: maestrodev
-        git_base: git@github.com:
+        git_base: 'git@github.com:'
       """
     And a file named "config_defaults.yml" with:
       """

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -136,7 +136,7 @@ module ModuleSync
           puts "There were no files to update in #{name}. Not committing."
         else
           puts git_error
-          exit(1)
+          raise
         end
       end
     end


### PR DESCRIPTION
…ived StandardError when using skip_broken option.  Also, must quote `git_base` option in feature setup, otherwise the YAML parser mistakenly interprets `git@github.com:` as a hash key (I think).