### PR TITLE
Honor repo default branch

### DIFF
--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -23,7 +23,7 @@ Given 'a remote module repository' do
   CONFIG
 end
 
-Given /a remote module repository with "(.+?)" as the default branch/ do |branch|
+Given /a remote module repository with "(.+?)" as the default branch/ do |branch| # rubocop:disable Lint/AmbiguousRegexpLiteral
   steps %(
     Given a directory named "sources"
     And I run `git clone --mirror https://github.com/maestrodev/puppet-test sources/puppet-test`

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -22,3 +22,26 @@ Given 'a remote module repository' do
   git_base: file://#{expand_path('.')}/
   CONFIG
 end
+
+Given /a remote module repository with "(.+?)" as the default branch/ do |branch|
+  steps %(
+    Given a directory named "sources"
+    And I run `git clone --mirror https://github.com/maestrodev/puppet-test sources/puppet-test`
+    And a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+  )
+  write_file('modulesync.yml', <<-CONFIG)
+---
+  namespace: sources
+  git_base: file://#{expand_path('.')}/
+  CONFIG
+  cd('sources/puppet-test') do
+    steps %(
+      And I run `git branch -M master #{branch}`
+      And I run `git symbolic-ref HEAD refs/heads/#{branch}`
+    )
+  end
+end

--- a/features/update.feature
+++ b/features/update.feature
@@ -885,3 +885,21 @@ Feature: update
     Then the exit status should be 0
     Then the output should not contain "error"
     Then the output should not contain "rejected"
+
+  Scenario: Repository with a default branch other than master
+    Given a mocked git configuration
+    And a remote module repository with "develop" as the default branch
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      Gemfile:
+        gem_source: https://somehost.com
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/Gemfile.erb" with:
+      """
+      source '<%= @configs['gem_source'] %>'
+      """
+    When I run `msync update -m "Update Gemfile"`
+    Then the exit status should be 0
+    Then the output should contain "Using repository's default branch: develop"

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -53,8 +53,8 @@ module ModuleSync
                    :desc => 'A regular expression to skip repositories.'
       class_option :branch,
                    :aliases => '-b',
-                   :desc => 'Branch name to make the changes in. Defaults to master.',
-                   :default => CLI.defaults[:branch] || 'master'
+                   :desc => 'Branch name to make the changes in. Defaults to the default branch of the upstream repository.',
+                   :default => CLI.defaults[:branch]
 
       desc 'update', 'Update the modules in managed_modules.yml'
       option :message,

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -53,7 +53,7 @@ module ModuleSync
                    :desc => 'A regular expression to skip repositories.'
       class_option :branch,
                    :aliases => '-b',
-                   :desc => 'Branch name to make the changes in. Defaults to the default branch of the upstream repository.',
+                   :desc => 'Branch name to make the changes in. Defaults to the default branch of the upstream repository, but falls back to "master".',
                    :default => CLI.defaults[:branch]
 
       desc 'update', 'Update the modules in managed_modules.yml'

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -19,6 +19,10 @@ module ModuleSync
     end
 
     def self.switch_branch(repo, branch)
+      unless branch
+        puts "Using repository's default branch"
+        return
+      end
       return if repo.current_branch == branch
 
       if local_branch_exists?(repo, branch)
@@ -100,6 +104,7 @@ module ModuleSync
       module_root = "#{options[:project_root]}/#{name}"
       message = options[:message]
       repo = ::Git.open(module_root)
+      options[:branch] ||= (repo.current_branch || 'master')
       repo.branch(options[:branch]).checkout
       files.each do |file|
         if repo.status.deleted.include?(file)
@@ -154,6 +159,7 @@ module ModuleSync
       puts "Using no-op. Files in #{name} may be changed but will not be committed."
 
       repo = ::Git.open("#{options[:project_root]}/#{name}")
+      options[:branch] ||= (repo.current_branch || 'master')
       repo.branch(options[:branch]).checkout
 
       puts 'Files changed:'

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -110,6 +110,7 @@ module ModuleSync
       repo.branch(selected_branch).checkout
       selected_branch
     end
+    private_class_method :checkout_branch
 
     # Git add/rm, git commit, git push
     def self.update(name, files, options)

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -2,7 +2,7 @@ require 'git'
 require 'puppet_blacksmith'
 
 module ModuleSync
-  module Git
+  module Git # rubocop:disable Metrics/ModuleLength
     include Constants
 
     def self.remote_branch_exists?(repo, branch)

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -18,10 +18,16 @@ module ModuleSync
         repo.diff("#{local_branch}..origin/#{remote_branch}").any?
     end
 
+    def self.default_branch(repo)
+      symbolic_ref = repo.branches.find { |b| b.full =~ %r{remotes/origin/HEAD} }
+      return unless symbolic_ref
+      %r{remotes/origin/HEAD\s+->\s+origin/(?<branch>.+?)$}.match(symbolic_ref.full)[:branch]
+    end
+
     def self.switch_branch(repo, branch)
       unless branch
-        puts "Using repository's default branch"
-        return
+        branch = default_branch(repo)
+        puts "Using repository's default branch: #{branch}"
       end
       return if repo.current_branch == branch
 


### PR DESCRIPTION
Fixes #133 #76.

I had to disable `Metrics/ModuleLength` because it was over by 11 lines but `Modulesync::Git` could use some refactoring I think.  I wasn't sure how far I should go with it so I figured I would file the PR and see where the discussion leads.