### PR TITLE
Add support to submit PRs to GitHub when changes are pushed

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ probably seems excessive. You can create a file called modulesync.yml in the
 configuration directory that provides these arguments automatically. This file
 has a form such as:
 
-```
+```yaml
 ---
 namespace: mygithubusername
 branch: modulesyncbranch
@@ -243,26 +243,28 @@ msync update -m "Commit message"
 
 Available parameters for modulesync.yml
 
-* git_base : The default URL to git clone from (Default: 'git@github.com:')
-* namespace : Namespace of the projects to manage (Default: 'puppetlabs')
-* branch : Branch to push to (Default: 'master')
-* remote_branch : Remote branch to push to (Default: Same value as branch)
-* message : Commit message to apply to updated modules.
-* pre_commit_script : A script to be run before commiting (e.g. 'contrib/myfooscript.sh')
+* `git_base` : The default URL to git clone from (Default: 'git@github.com:')
+* `namespace` : Namespace of the projects to manage (Default: 'puppetlabs')
+* `branch` : Branch to push to (Default: 'master')
+* `remote_branch` : Remote branch to push to (Default: Same value as branch)
+* `message` : Commit message to apply to updated modules.
+* `pre_commit_script` : A script to be run before commiting (e.g. 'contrib/myfooscript.sh')
+* `pr_title` : The title to use when submitting PRs to GitHub.
 
 ##### Example
 
 ###### Github
 
-```
+```yaml
 ---
 namespace: MySuperOrganization
 branch: modulesyncbranch
+pr_title: "Updates to module template files via modulesync"
 ```
 
 ###### Gitlab
 
-```
+```yaml
 ---
 git_base: 'user@gitlab.example.com:'
 namespace: MySuperOrganization
@@ -271,7 +273,7 @@ branch: modulesyncbranch
 
 ###### Gerrit
 
-```
+```yaml
 ---
 namespace: stackforge
 git_base:  ssh://jdoe@review.openstack.org:29418/
@@ -367,7 +369,7 @@ If `CHANGELOG.md` is absent in the repository, nothing will happen.
 
 As commented, files within moduleroot directory can be flat files or ERB templates. These files have direct access to @configs hash, which gets values from config_defaults.yml file and from the module being processed:
 
-```
+```erb
 <%= @configs[:git_base] %>
 <%= @configs[:namespace] %>
 <%= @configs[:puppet_module] %>

--- a/README.md
+++ b/README.md
@@ -185,9 +185,14 @@ You can have modulesync submit Pull Requests on GitHub automatically with the
 msync update --pr
 ```
 
-You must set `GITHUB_TOKEN` in your environment for this to work. You can set
-the PR title with `--pr-title` or in `modulesync.yml` with the `pr_title`
-attribute.
+You must set `GITHUB_TOKEN` in your environment for this to work. Other options
+include:
+
+* Set the PR title with `--pr-title` or in `modulesync.yml` with the `pr_title`
+  attribute.
+* Assign labels to the PR with `--pr-labels` or in `modulesync.yml` with the
+  `pr_labels` attribute. **NOTE:** `pr_labels` should be a list. When using
+  the `--pr-labels` CLI option, you should use a comma separated list.
 
 ### Using Forks and Non-master branches
 
@@ -250,6 +255,7 @@ Available parameters for modulesync.yml
 * `message` : Commit message to apply to updated modules.
 * `pre_commit_script` : A script to be run before commiting (e.g. 'contrib/myfooscript.sh')
 * `pr_title` : The title to use when submitting PRs to GitHub.
+* `pr_labels` : A list of labels to assign PRs created on GitHub.
 
 ##### Example
 
@@ -260,6 +266,10 @@ Available parameters for modulesync.yml
 namespace: MySuperOrganization
 branch: modulesyncbranch
 pr_title: "Updates to module template files via modulesync"
+pr_labels:
+  - TOOLING
+  - MAINTENANCE
+  - MODULESYNC
 ```
 
 ###### Gitlab

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ include:
   `pr_labels` attribute. **NOTE:** `pr_labels` should be a list. When using
   the `--pr-labels` CLI option, you should use a comma separated list.
 
+You can optionally set the `GITHUB_BASE_URL` environment variable to use GitHub
+Enterprise. This is passed to Octokit's [`api_endpoint`](https://github.com/octokit/octokit.rb#interacting-with-the-githubcom-apis-in-github-enterprise) 
+configuration option.
+
 ### Using Forks and Non-master branches
 
 The default functionality is to run ModuleSync on the puppetlabs modules, but

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake/clean'
 require 'cucumber/rake/task'
 require 'rubocop/rake_task'
+require 'octokit'
 
 begin
   require 'rspec/core/rake_task'

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require 'rake/clean'
 require 'cucumber/rake/task'
 require 'rubocop/rake_task'
-require 'octokit'
 
 begin
   require 'rspec/core/rake_task'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -139,7 +139,7 @@ module ModuleSync
 
         # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
         # already exist. We DO NOT create missing labels.
-        if !pr_labels.empty?
+        unless pr_labels.empty?
           puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
           github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
         end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -96,6 +96,11 @@ module ModuleSync
   end
 
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
+    if option[:pr] && !GITHUB_TOKEN
+        STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+        raise unless options[:skip_broken]
+    end
+
     puts "Syncing #{puppet_module}"
     namespace, module_name = module_name(puppet_module, options[:namespace])
     unless options[:offline]
@@ -120,31 +125,27 @@ module ModuleSync
 
     if options[:noop]
       Git.update_noop(module_name, options)
-    elsif !options[:offline]
+    elsif !options[:offline] && options[:pr]
       # Git.update() returns a boolean: true if files were pushed, false if not.
       pushed = Git.update(module_name, files_to_manage, options)
       return nil unless pushed
 
-      if options[:pr] && GITHUB_TOKEN
-        # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
-        repo_path = "#{namespace}/#{module_name}"
-        puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
-        github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-        pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
-        puts "PR created at #{pr['html_url']}"
+      # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
+      repo_path = "#{namespace}/#{module_name}"
+      puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
+      github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
+      pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
+      puts "PR created at #{pr['html_url']}"
 
-        # PR labels can either be a list in the YAML file or they can pass in a comma
-        # separated list via the command line argument.
-        pr_labels = Util.parse_list(options[:pr_labels])
+      # PR labels can either be a list in the YAML file or they can pass in a comma
+      # separated list via the command line argument.
+      pr_labels = Util.parse_list(options[:pr_labels])
 
-        # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
-        # already exist. We DO NOT create missing labels.
-        unless pr_labels.empty?
-          puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
-          github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
-        end
-      else
-        puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+      # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
+      # already exist. We DO NOT create missing labels.
+      unless pr_labels.empty?
+        puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
+        github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
       end
     end
   end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -1,4 +1,4 @@
-eenuire 'fileutils'
+require 'fileutils'
 require 'octokit'
 require 'pathname'
 require 'modulesync/cli'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -122,15 +122,15 @@ module ModuleSync
       Git.update_noop(module_name, options)
     elsif !options[:offline]
       pushed = Git.update(module_name, files_to_manage, options)
-      if pushed and options[:pr]
+      if pushed && options[:pr]
         if GITHUB_TOKEN
           repo_path = "#{namespace}/#{module_name}"
           puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
           github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-          pr = github.create_pull_request(repo_path, "master", options[:branch], options[:pr_title], options[:message])
-          puts "PR created at #{pr["html_url"]}"
+          pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
+          puts "PR created at #{pr['html_url']}"
         else
-          puts "Environment variable GITHUB_TOKEN must be set to use --pr!"
+          puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
         end
       end
     end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -144,7 +144,7 @@ module ModuleSync
 
           # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
           # already exist. We DO NOT create missing labels.
-          if pr_labels.length:
+          if pr_labels.length
             puts "Attaching the following labels to PR #{pr['id']}: #{pr_labels.join(', ')}"
             github.add_labels_to_an_issue(repo_path, pr['id'], pr_labels)
           end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -125,10 +125,10 @@ module ModuleSync
 
     if options[:noop]
       Git.update_noop(module_name, options)
-    elsif !options[:offline] && options[:pr]
+    elsif !options[:offline]
       # Git.update() returns a boolean: true if files were pushed, false if not.
       pushed = Git.update(module_name, files_to_manage, options)
-      return nil unless pushed
+      return nil unless pushed && options[:pr]
 
       # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
       repo_path = "#{namespace}/#{module_name}"

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -96,9 +96,9 @@ module ModuleSync
   end
 
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
-    if option[:pr] && !GITHUB_TOKEN
-        STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
-        raise unless options[:skip_broken]
+    if options[:pr] && !GITHUB_TOKEN
+      STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+      raise unless options[:skip_broken]
     end
 
     puts "Syncing #{puppet_module}"

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -121,14 +121,33 @@ module ModuleSync
     if options[:noop]
       Git.update_noop(module_name, options)
     elsif !options[:offline]
+      # Git.update() returns a boolean: true if files were pushed, false if not.
       pushed = Git.update(module_name, files_to_manage, options)
       if pushed && options[:pr]
+        # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
         if GITHUB_TOKEN
           repo_path = "#{namespace}/#{module_name}"
           puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
           github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
           pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
           puts "PR created at #{pr['html_url']}"
+
+          # PR labels can either be a list in the YAML file or they can pass in a comma 
+          # separated list via the command line argument.
+          if options[:pr_labels].is_a? String
+            pr_labels = options[:pr_labels].split(',')
+          elsif options[:pr_labels].is_a? Array
+            pr_labels = options[:pr_labels]
+          else
+            pr_labels = []
+          end
+
+          # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
+          # already exist. We DO NOT create missing labels.
+          if pr_labels.length:
+            puts "Attaching the following labels to PR #{pr['id']}: #{pr_labels.join(', ')}"
+            github.add_labels_to_an_issue(repo_path, pr['id'], pr_labels)
+          end
         else
           puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
         end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -1,4 +1,4 @@
-require 'fileutils'
+eenuire 'fileutils'
 require 'octokit'
 require 'pathname'
 require 'modulesync/cli'
@@ -123,34 +123,28 @@ module ModuleSync
     elsif !options[:offline]
       # Git.update() returns a boolean: true if files were pushed, false if not.
       pushed = Git.update(module_name, files_to_manage, options)
-      if pushed && options[:pr]
+      return nil unless pushed
+
+      if options[:pr] && GITHUB_TOKEN
         # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
-        if GITHUB_TOKEN
-          repo_path = "#{namespace}/#{module_name}"
-          puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
-          github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-          pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
-          puts "PR created at #{pr['html_url']}"
+        repo_path = "#{namespace}/#{module_name}"
+        puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
+        github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
+        pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
+        puts "PR created at #{pr['html_url']}"
 
-          # PR labels can either be a list in the YAML file or they can pass in a comma 
-          # separated list via the command line argument.
-          if options[:pr_labels].is_a? String
-            pr_labels = options[:pr_labels].split(',')
-          elsif options[:pr_labels].is_a? Array
-            pr_labels = options[:pr_labels]
-          else
-            pr_labels = []
-          end
+        # PR labels can either be a list in the YAML file or they can pass in a comma
+        # separated list via the command line argument.
+        pr_labels = Util.parse_list(options[:pr_labels])
 
-          # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
-          # already exist. We DO NOT create missing labels.
-          if pr_labels.length
-            puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
-            github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
-          end
-        else
-          puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+        # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
+        # already exist. We DO NOT create missing labels.
+        if pr_labels.length
+          puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
+          github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
         end
+      else
+        puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
       end
     end
   end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -145,8 +145,8 @@ module ModuleSync
           # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
           # already exist. We DO NOT create missing labels.
           if pr_labels.length
-            puts "Attaching the following labels to PR #{pr['id']}: #{pr_labels.join(', ')}"
-            github.add_labels_to_an_issue(repo_path, pr['id'], pr_labels)
+            puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
+            github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
           end
         else
           puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -139,7 +139,7 @@ module ModuleSync
 
         # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
         # already exist. We DO NOT create missing labels.
-        if pr_labels.length
+        if !pr_labels.empty?
           puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
           github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
         end

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -92,6 +92,9 @@ module ModuleSync
       option :pr_title,
              :desc => 'Title of GitHub PR',
              :default => CLI.defaults[:pr_title] || 'Update to module template files'
+      option :pr_labels,
+             :desc => 'Labels to add to the GitHub PR',
+             :default => CLI.defaults[:pr_labels] || []
       option :offline,
              :type => :boolean,
              :desc => 'Do not run any Git commands. Allows the user to manage Git outside of ModuleSync.',

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -90,7 +90,6 @@ module ModuleSync
              :desc => 'Submit GitHub PR',
              :default => false
       option :pr_title,
-             :type => :boolean,
              :desc => 'Title of GitHub PR',
              :default => CLI.defaults[:pr_title] || 'Update to module template files'
       option :offline,

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -158,7 +158,7 @@ module ModuleSync
         end
       end
 
-      return true
+      true
     end
 
     # Needed because of a bug in the git gem that lists ignored files as

--- a/lib/modulesync/util.rb
+++ b/lib/modulesync/util.rb
@@ -14,5 +14,13 @@ module ModuleSync
         {}
       end
     end
+
+    def self.parse_list(option_value)
+      if option_value.is_a? String
+        option_value.split(',')
+      elsif option_value.is_a? Array
+        options[:pr_labels]
+      end
+    end
   end
 end

--- a/lib/modulesync/util.rb
+++ b/lib/modulesync/util.rb
@@ -19,7 +19,9 @@ module ModuleSync
       if option_value.is_a? String
         option_value.split(',')
       elsif option_value.is_a? Array
-        options[:pr_labels]
+        option_value
+      else
+        []
       end
     end
   end


### PR DESCRIPTION
This adds two new CLI options for the `update` command:

* `--pr` is a boolean value that when set will submit a PR to GitHub if updates have been pushed.
* `--pr-title` is a string that will be used for the title of the PR when submitting a PR to GitHub. `-m` is used as the PR's body. You can set this in `modulesync.yml` using the `pr_title` attribute.
* `--pr-labels` is a string of labels to assign the PR. `pr_labels` in `modulesync.yml` is expected to be a list, but a string should work as well.

A few notes about behavior:

* Will not run if `--noop` is passed.
* Will not push a PR if no files have been changed/pushed. `Git.update` was changed to facilitate this behavior. 
* Users must set a GitHub OAuth token in `GITHUB_TOKEN` for this to work.