### PR TITLE
Copy file permissions from template to target

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -84,10 +84,11 @@ module ModuleSync
       Renderer.remove(module_file(options[:project_root], module_name, filename))
     else
       templatename = local_file(options[:configs], filename)
+      mode = File.stat("#{templatename}.erb").mode
       begin
         erb = Renderer.build(templatename)
         template = Renderer.render(erb, configs)
-        Renderer.sync(template, module_file(options[:project_root], module_name, filename))
+        Renderer.sync(template, module_file(options[:project_root], module_name, filename), mode)
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
         STDERR.puts "Error while rendering #{filename}"
         raise

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -84,7 +84,12 @@ module ModuleSync
       Renderer.remove(module_file(options[:project_root], module_name, filename))
     else
       templatename = local_file(options[:configs], filename)
-      mode = File.stat("#{templatename}.erb").mode
+      template_file = if !File.exist?("#{templatename}.erb") && File.exist?(templatename)
+                        templatename
+                      else
+                        "#{templatename}.erb"
+                      end
+      mode = File.stat(template_file).mode
       begin
         erb = Renderer.build(templatename)
         template = Renderer.render(erb, configs)

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -30,12 +30,13 @@ module ModuleSync
       ForgeModuleFile.new(configs).render
     end
 
-    def self.sync(template, target_name)
+    def self.sync(template, target_name, mode)
       path = target_name.rpartition('/').first
       FileUtils.mkdir_p(path) unless path.empty?
       File.open(target_name, 'w') do |file|
         file.write(template)
       end
+      File.chmod(mode, target_name)
     end
   end
 end

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -30,13 +30,13 @@ module ModuleSync
       ForgeModuleFile.new(configs).render
     end
 
-    def self.sync(template, target_name, mode)
+    def self.sync(template, target_name, mode = nil)
       path = target_name.rpartition('/').first
       FileUtils.mkdir_p(path) unless path.empty?
       File.open(target_name, 'w') do |file|
         file.write(template)
       end
-      File.chmod(mode, target_name)
+      File.chmod(mode, target_name) unless mode.nil?
     end
   end
 end


### PR DESCRIPTION
I have a couple of executable scripts to sync (like a `config_version.rb`), this patch has msync make the rendered output files have the same permissions as the source .erb. 


`File.chmod` the rendered template to mimic the source .erb file,
to allow (for instance) executable scripts to be synced by modulesync