### PR TITLE
Add the ability to automatically merge downstream PRs created by modulesync

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'tmp/**/*'
     - 'pkg/**/*'
     - 'lib/monkey_patches.rb'
+    - 'spec/**/*'
 
 Style/HashSyntax:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ include:
 * Assign labels to the PR with `--pr-labels` or in `modulesync.yml` with the
   `pr_labels` attribute. **NOTE:** `pr_labels` should be a list. When using
   the `--pr-labels` CLI option, you should use a comma separated list.
+* `--pr-auto-merge` will attempt to automatically merge downstream PRs created
+  by modulesync. Skips PRs that aren't able to be merged when the 
+  `--skip-broken` option is passed.
 
 You can optionally set the `GITHUB_BASE_URL` environment variable to use GitHub
 Enterprise. This is passed to Octokit's [`api_endpoint`](https://github.com/octokit/octokit.rb#interacting-with-the-githubcom-apis-in-github-enterprise) 

--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,5 @@ Cucumber::Rake::Task.new do |t|
 end
 
 task :test => %i[clean spec cucumber rubocop]
+
+task :default => ["test"]

--- a/Rakefile
+++ b/Rakefile
@@ -20,4 +20,4 @@ end
 
 task :test => %i[clean spec cucumber rubocop]
 
-task :default => ["test"]
+task :default => ['test']

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -46,7 +46,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
           .collect { |p| p.chomp('.erb') }
           .to_a
     else
-      puts "#{local_template_dir} does not exist." \
+      $stdout.puts "#{local_template_dir} does not exist." \
         ' Check that you are working in your module configs directory or' \
         ' that you have passed in the correct directory with -c.'
       exit
@@ -60,7 +60,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   def self.managed_modules(config_file, filter, negative_filter)
     managed_modules = Util.parse_config(config_file)
     if managed_modules.empty?
-      puts "No modules found in #{config_file}." \
+      $stdout.puts "No modules found in #{config_file}." \
         ' Check that you specified the right :configs directory and :managed_modules_conf file.'
       exit
     end
@@ -98,18 +98,13 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
         template = Renderer.render(erb, configs)
         Renderer.sync(template, module_file(options[:project_root], namespace, module_name, filename))
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
-        STDERR.puts "Error while rendering #{filename}"
+        $stderr.puts "Error while rendering #{filename}"
         raise
       end
     end
   end
 
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
-    if options[:pr] && !GITHUB_TOKEN
-      STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
-      raise unless options[:skip_broken]
-    end
-
     namespace, module_name = module_name(puppet_module, options[:namespace])
     git_repo = File.join(namespace, module_name)
     unless options[:offline]
@@ -125,7 +120,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
                             :git_base => options[:git_base],
                             :namespace => namespace)
     settings.unmanaged_files(module_files).each do |filename|
-      puts "Not managing #{filename} in #{module_name}"
+      $stdout.puts "Not managing #{filename} in #{module_name}"
     end
 
     files_to_manage = settings.managed_files(module_files)
@@ -141,11 +136,16 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   end
 
   def self.manage_pr(git_repo, options)
+    if options[:pr] && GITHUB_TOKEN.empty?
+      $stderr.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+      raise unless options[:skip_broken]
+    end
+
     # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
-    puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{git_repo} - merges #{options[:branch]} into master"
+    $stdout.puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{git_repo} - merges #{options[:branch]} into master"
     github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
     pr = github.create_pull_request(git_repo, 'master', options[:branch], options[:pr_title], options[:message])
-    puts "PR created at #{pr['html_url']}"
+    $stdout.puts "PR created at #{pr['html_url']}"
 
     # PR labels can either be a list in the YAML file or they can pass in a comma
     # separated list via the command line argument.
@@ -154,7 +154,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
     # already exist. We DO NOT create missing labels.
     unless pr_labels.empty?
-      puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
+      $stdout.puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
       github.add_labels_to_an_issue(git_repo, pr['number'], pr_labels)
     end
 
@@ -164,10 +164,10 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     # if they specify --skip-broken.
     begin
       github.merge_pull_request(git_repo, pr['number'], "Auto-merge modulesync generated PR #{pr['number']}")
-      puts "Automatically merged PR #{pr['number']}"
+      $stdout.puts "Automatically merged PR #{pr['number']}"
     rescue Octokit::Error => exception
       raise unless options[:skip_broken]
-      puts "Could not automatically merge PR #{pr['number']}: #{exception}"
+      $std.outputs "Could not automatically merge PR #{pr['number']}: #{exception}"
     end
   end
 
@@ -189,10 +189,10 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
       begin
         manage_module(puppet_module, module_files, module_options, defaults, options)
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
-        STDERR.puts "Error while updating #{puppet_module}"
+        $stderr.puts "Error while updating #{puppet_module}"
         raise unless options[:skip_broken]
         errors = true
-        puts "Skipping #{puppet_module} as update process failed"
+        $stdout.puts "Skipping #{puppet_module} as update process failed"
       end
     end
     exit 1 if errors && options[:fail_on_warnings]

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -16,7 +16,7 @@ Octokit.configure do |c|
   c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com')
 end
 
-module ModuleSync
+module ModuleSync # rubocop:disable Metrics/ModuleLength
   include Constants
 
   def self.config_defaults

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -142,7 +142,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     end
 
     # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
-    $stdout.puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{git_repo} - merges #{options[:branch]} into master"
+    $stdout.puts "Submitted PR '#{options[:pr_title]}' to #{git_repo} - merges #{options[:branch]} into master"
     github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
     pr = github.create_pull_request(git_repo, 'master', options[:branch], options[:pr_title], options[:message])
     $stdout.puts "PR created at #{pr['html_url']}"
@@ -167,7 +167,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
       $stdout.puts "Automatically merged PR #{pr['number']}"
     rescue Octokit::Error => exception
       raise unless options[:skip_broken]
-      $std.outputs "Could not automatically merge PR #{pr['number']}: #{exception}"
+      $stdout.outputs "Could not automatically merge PR #{pr['number']}: #{exception}"
     end
   end
 

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -142,10 +142,9 @@ module ModuleSync
 
   def self.manage_pr(git_repo, options)
     # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
-    repo_path = "#{namespace}/#{module_name}"
-    puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
+    puts "Submitting PR '#{options[:pr_title]}' on GitHub to #{git_repo} - merges #{options[:branch]} into master"
     github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-    pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
+    pr = github.create_pull_request(git_repo, 'master', options[:branch], options[:pr_title], options[:message])
     puts "PR created at #{pr['html_url']}"
 
     # PR labels can either be a list in the YAML file or they can pass in a comma

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -95,6 +95,10 @@ module ModuleSync
       option :pr_labels,
              :desc => 'Labels to add to the GitHub PR',
              :default => CLI.defaults[:pr_labels] || []
+      option :pr_auto_merge,
+             :type => :boolean,
+             :desc => 'Automatically merge downstream PRs',
+             :default => false
       option :offline,
              :type => :boolean,
              :desc => 'Do not run any Git commands. Allows the user to manage Git outside of ModuleSync.',

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -11,4 +11,54 @@ describe ModuleSync do
       ModuleSync.update(options)
     end
   end
+
+  context '::manage_pr' do
+    before(:each) do
+      stub_const('GITHUB_TOKEN', 'test')
+      @git_repo = 'test/modulesync'
+      @options = {
+        :pr => true,
+        :pr_title => 'Test PR is submitted',
+        :branch => 'test',
+        :message => 'Hello world',
+        :pr_auto_merge => false,
+      }
+
+      @client = double()
+    end
+
+    it 'rasies an error when GITHUB_TOKEN not set for PRs' do
+      stub_const('GITHUB_TOKEN', '')
+      options = {:pr => true, :skip_broken => false}
+
+      expect { ModuleSync.manage_pr(nil, options) }.to raise_error(RuntimeError).and output(/GITHUB_TOKEN/).to_stderr
+    end
+
+    it 'submits PR when --pr is set' do
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+
+      expect(@client).to receive(:create_pull_request).with(@git_repo, 'master', @options[:branch], @options[:pr_title], @options[:message]).and_return({"html_url" => "http://example.com/pulls/22"})
+      expect { ModuleSync.manage_pr(@git_repo, @options) }.to output(/PR created at/).to_stdout
+    end
+
+    it 'adds labels to PR when --pr-labels is set' do
+      @options[:pr_labels] = "HELLO,WORLD"
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+
+      allow(@client).to receive(:create_pull_request).and_return({"html_url" => "http://example.com/pulls/22", "number" => "44"})
+
+      expect(@client).to receive(:add_labels_to_an_issue).with(@git_repo, "44", ["HELLO", "WORLD"])
+      expect { ModuleSync.manage_pr(@git_repo, @options) }.to output(/Attaching the following labels to PR 44: HELLO, WORLD/).to_stdout
+    end
+
+    it 'auto-merges the PR when --pr-auto-merge is set' do
+      @options[:pr_auto_merge] = true
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+
+      allow(@client).to receive(:create_pull_request).and_return({"html_url" => "http://example.com/pulls/22", "number" => "44"})
+
+      expect(@client).to receive(:merge_pull_request).with(@git_repo, "44", "Auto-merge modulesync generated PR 44")
+      expect { ModuleSync.manage_pr(@git_repo, @options) }.to output(/Automatically merged PR 44/).to_stdout
+    end
+  end
 end


### PR DESCRIPTION
## What does this PR do?

* Introduces a `manage_pr` function. Rubocop was (rightfully) complaining about the complexity of this block and brings the PR code a bit more in line with the existing `manage_${thing}` pattern.
* Introduces `--pr-auto-merge` to automatically merge downstream PRs created by Modulesync. 
* Excludes `spec/` from Rubocop checks.
* Switches to `$stdout` and `$stderr`, which worked best with RSpec's `output()` checks.

## Why is this change being made?

My team and I are so lazy we can't be bothered to manually merge all of the PRs our robots make. This lets our robots do it for us. 🤖😂 

## How was this tested? How can the reviewer verify your testing?

We're still testing this. Please consider this a work in progress until I've confirmed later.

## What gif best describes this PR or how it makes you feel?

![](https://laughingsquid.com/wp-content/uploads/2018/02/boston-dynamics-upgraded-spotmini-robot-can-now-open-doors-for-others.gif?w=750)