### PR TITLE
Fix "flat files" still mentioned in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Available parameters for modulesync.yml
 
 ##### Example
 
-###### Github
+###### GitHub
 
 ```yaml
 ---
@@ -276,7 +276,7 @@ pr_labels:
   - MODULESYNC
 ```
 
-###### Gitlab
+###### GitLab
 
 ```yaml
 ---
@@ -379,9 +379,9 @@ current date, bumped (minor) version, and commit message.
 If `CHANGELOG.md` is absent in the repository, nothing will happen.
 
 
-#### Defining templates
+#### Working with templates
 
-As commented, files within moduleroot directory can be flat files or ERB templates. These files have direct access to @configs hash, which gets values from config_defaults.yml file and from the module being processed:
+As mentioned, files in the moduleroot directory must be ERB templates (they must have an .erb extension, or they will be ignored). These files have direct access to @configs hash, which gets values from config_defaults.yml file and from the module being processed:
 
 ```erb
 <%= @configs[:git_base] %>


### PR DESCRIPTION
As mentioned in https://github.com/voxpupuli/modulesync/pull/114#issuecomment-391982465 flat files are still mentioned in the README while technically an `.erb` extension is now required for all files that should be taken into consideration by modulesync.

This PR updates the outdated text and fixes two spelling mistakes (brand names).

*Sponsored by @vshn, The DevOps Company*