### PR TITLE
Fix opts[:remote] call when using hashes for configs

### DIFF
--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -51,7 +51,7 @@ module ModuleSync
       # Repo needs to be cloned in the cwd
       if !Dir.exist?("#{project_root}/#{name}") || !Dir.exist?("#{project_root}/#{name}/.git")
         puts 'Cloning repository fresh'
-        remote = opts[:remote] || (git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
+        remote = opts['remote'] || (git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
         local = "#{project_root}/#{name}"
         puts "Cloning from #{remote}"
         repo = ::Git.clone(remote, local)


### PR DESCRIPTION
When you use a [hash instead of a list](https://github.com/voxpupuli/modulesync/blob/master/lib/modulesync.rb#L164) in `managed_modules.yml` the keys in `module_options` are strings and not symbols. This results in [`opts[:remote]`](https://github.com/voxpupuli/modulesync/blob/master/lib/modulesync/git.rb#L54) being ignored.

I ran across this when using AWS CodeCommit, which doesn't use `.git` suffixes on their URIs. The following `managed_modules.yml` works with this fix:

```yaml
---
my-fancy-repo:
  remote: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/my-fancy-repo
```