### PR TITLE
Add -t option to populate managed modules using GitHub's repository topics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'
-gem 'octokit', '~> 4.0'
+gem 'octokit', '~> 4.12'

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -16,11 +16,13 @@ GITHUB_ORGANIZATION = ENV.fetch('GITHUB_ORGANIZATION', '')
 Octokit.configure do |c|
   c.api_endpoint = ENV.fetch('GITHUB_BASE_URL', 'https://api.github.com')
   c.auto_paginate = true
+
+  # We use a different Accept header by default here so we can get access
+  # to the developer's preview that enables repository topics.
   c.default_media_type = ::Octokit::Preview::PREVIEW_TYPES[:topics]
 end
 
 GITHUB = Octokit::Client.new(:access_token => GITHUB_TOKEN)
-
 
 module ModuleSync
   include Constants
@@ -59,10 +61,8 @@ module ModuleSync
   def self.managed_modules(config_file, filter, negative_filter, topic)
     if topic
       managed_modules = []
-      GITHUB.org_repos(GITHUB_ORGANIZATION, {:type => 'all'}).each do |repo|
-        if repo.topics.include?(topic)
-          managed_modules.push(repo.name)
-        end
+      GITHUB.org_repos(GITHUB_ORGANIZATION).each do |repo|
+        managed_modules.push(repo.name) if repo.topics.include?(topic)
       end
     else
       managed_modules = Util.parse_config(config_file)

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -51,6 +51,9 @@ module ModuleSync
       class_option :negative_filter,
                    :aliases => '-x',
                    :desc => 'A regular expression to skip repositories.'
+      class_option :topic,
+                   :aliases => '-t',
+                   :desc => 'Use GitHub topic to populate list of managed modules.'
       class_option :branch,
                    :aliases => '-b',
                    :desc => 'Branch name to make the changes in. Defaults to the default branch of the upstream repository, but falls back to "master".',


### PR DESCRIPTION
GitHub supports [tagging repositories with "topics"](https://developer.github.com/v3/repos/#list-organization-repositories). This PR leverages this functionality to populate a list of managed modules rather than having to manually maintain `managed_modules.yml`.

This allows teams to add the topic `ruby` to a GitHub repository and then use the `-t ruby` option in their Ruby Modulesync CI/CD job to grab all of the repositories to sync.