### PR TITLE
Add AWS Codecommit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ remote_branch: refs/publish/master/msync_foo
 pre_commit_script: openstack-commit-msg-hook.sh
 ```
 
+###### AWS Codecommit
+
+```
+---
+gitbase: https://git-commit.us-east-1.amazonaws.com/
+branch: modulesyncbranch
+```
+
 #### Filtering Repositories
 
 If you only want to sync some of the repositories in your managed_modules.yml, use the `-f` flag to filter by a regex:

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -105,9 +105,7 @@ module ModuleSync
     namespace, module_name = module_name(puppet_module, options[:namespace])
     unless options[:offline]
       git_base = options[:git_base]
-      if git_base.include? 'git-codecommit'
-        namespace = 'v1/repos'
-      end
+      git_base.include?('git-codecommit') && namespace = 'v1/repos'
 
       git_uri = "#{git_base}#{namespace}"
       Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -105,6 +105,10 @@ module ModuleSync
     namespace, module_name = module_name(puppet_module, options[:namespace])
     unless options[:offline]
       git_base = options[:git_base]
+      if git_base.include? 'git-codecommit'
+        namespace = 'v1/repos'
+      end
+
       git_uri = "#{git_base}#{namespace}"
       Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
     end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -95,6 +95,10 @@ module ModuleSync
     end
   end
 
+  def codecommit?(git_base, namespace)
+    git_base.include?('git-codecommit') && 'v1/repos' || namespace
+  end
+
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
     if options[:pr] && !GITHUB_TOKEN
       STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
@@ -105,8 +109,6 @@ module ModuleSync
     namespace, module_name = module_name(puppet_module, options[:namespace])
     unless options[:offline]
       git_base = options[:git_base]
-      git_base.include?('git-codecommit') && namespace = 'v1/repos'
-
       git_uri = "#{git_base}#{namespace}"
       Git.pull(git_uri, module_name, options[:branch], options[:project_root], module_options || {})
     end
@@ -117,7 +119,7 @@ module ModuleSync
                             module_configs,
                             :puppet_module => module_name,
                             :git_base => git_base,
-                            :namespace => namespace)
+                            :namespace => codecommit?(git_base, namespace))
     settings.unmanaged_files(module_files).each do |filename|
       puts "Not managing #{filename} in #{module_name}"
     end

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -51,7 +51,7 @@ module ModuleSync
       # Repo needs to be cloned in the cwd
       if !Dir.exist?("#{project_root}/#{name}") || !Dir.exist?("#{project_root}/#{name}/.git")
         puts 'Cloning repository fresh'
-        remote = opts[:remote] || (git_base.start_with?('file://') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
+        remote = opts[:remote] || (( git_base.start_with?('file://') or git_base.include? 'git-codecommit') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
         local = "#{project_root}/#{name}"
         puts "Cloning from #{remote}"
         repo = ::Git.clone(remote, local)

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -51,7 +51,7 @@ module ModuleSync
       # Repo needs to be cloned in the cwd
       if !Dir.exist?("#{project_root}/#{name}") || !Dir.exist?("#{project_root}/#{name}/.git")
         puts 'Cloning repository fresh'
-        remote = opts[:remote] || (( git_base.start_with?('file://') or git_base.include? 'git-codecommit') ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git")
+        remote = opts[:remote] || (git_base.start_with?('file://') || git_base.include?('git-codecommit')) ? "#{git_base}/#{name}" : "#{git_base}/#{name}.git"
         local = "#{project_root}/#{name}"
         puts "Cloning from #{remote}"
         repo = ::Git.clone(remote, local)


### PR DESCRIPTION
AWS Codecommit doesn't have either `.git` at the end of the url nor the concept of namespaces. For example, codecommit urls are in the form of `{ssh,https}://git-codecommit.<aws_region>.amazonaws.com/v1/repos/<reponame>`