### PR TITLE
Small improvements and fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,7 @@ Style/TrailingCommaInLiteral:
 # would require external library
 Layout/IndentHeredoc:
   Enabled: false
+
+# sane line length
+Metrics/LineLength:
+  Max: 120

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -25,11 +25,6 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 13
 
-# Offense count: 29
-# Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
-  Max: 319
-
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/MethodLength:

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -23,7 +23,7 @@ Given 'a remote module repository' do
   CONFIG
 end
 
-Given /a remote module repository with "(.+?)" as the default branch/ do |branch| # rubocop:disable Lint/AmbiguousRegexpLiteral
+Given Regexp.new(/a remote module repository with "(.+?)" as the default branch/) do |branch|
   steps %(
     Given a directory named "sources"
     And I run `git clone --mirror https://github.com/maestrodev/puppet-test sources/puppet-test`

--- a/features/update.feature
+++ b/features/update.feature
@@ -113,7 +113,7 @@ Feature: update
     Then the exit status should be 0
     And the output should match:
       """
-      Warning: using './moduleroot//test' as template without '.erb' suffix
+      Warning: using './moduleroot/test' as template without '.erb' suffix
       """
     And the output should match:
       """

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -36,12 +36,19 @@ module ModuleSync
     File.join(project_root, namespace, puppet_module, file)
   end
 
-  def self.local_files(path)
-    if File.exist?(path)
-      # only select *.erb files, and strip the extension. This way all the code will only have to handle bare paths, except when reading the actual ERB text
-      local_files = Find.find(path).find_all { |p| p =~ /.erb$/ && !File.directory?(p) }.collect { |p| p.chomp('.erb') }.to_a
+  # List all template files.
+  #
+  # Only select *.erb files, and strip the extension. This way all the code will only have to handle bare paths,
+  # except when reading the actual ERB text
+  def self.find_template_files(local_template_dir)
+    if File.exist?(local_template_dir)
+      Find.find(local_template_dir).find_all { |p| p =~ /.erb$/ && !File.directory?(p) }
+          .collect { |p| p.chomp('.erb') }
+          .to_a
     else
-      puts "#{path} does not exist. Check that you are working in your module configs directory or that you have passed in the correct directory with -c."
+      puts "#{local_template_dir} does not exist." \
+        ' Check that you are working in your module configs directory or' \
+        ' that you have passed in the correct directory with -c.'
       exit
     end
   end
@@ -154,7 +161,7 @@ module ModuleSync
     defaults = Util.parse_config(File.join(options[:configs], CONF_FILE))
 
     path = File.join(options[:configs], MODULE_FILES_DIR)
-    local_files = self.local_files(path)
+    local_files = find_template_files(path)
     module_files = self.module_files(local_files, path)
 
     managed_modules = self.managed_modules(File.join(options[:configs], options[:managed_modules_conf]),

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -53,8 +53,8 @@ module ModuleSync
     end
   end
 
-  def self.module_files(local_files, path)
-    local_files.map { |file| file.sub(/#{path}/, '') }
+  def self.relative_names(file_list, path)
+    file_list.map { |file| file.sub(/#{path}/, '') }
   end
 
   def self.managed_modules(config_file, filter, negative_filter)
@@ -162,7 +162,7 @@ module ModuleSync
 
     local_template_dir = File.join(options[:configs], MODULE_FILES_DIR)
     local_files = find_template_files(local_template_dir)
-    module_files = self.module_files(local_files, local_template_dir)
+    module_files = relative_names(local_files, local_template_dir)
 
     managed_modules = self.managed_modules(File.join(options[:configs], options[:managed_modules_conf]),
                                            options[:filter],

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -160,9 +160,9 @@ module ModuleSync
     options = config_defaults.merge(options)
     defaults = Util.parse_config(File.join(options[:configs], CONF_FILE))
 
-    path = File.join(options[:configs], MODULE_FILES_DIR)
-    local_files = find_template_files(path)
-    module_files = self.module_files(local_files, path)
+    local_template_dir = File.join(options[:configs], MODULE_FILES_DIR)
+    local_files = find_template_files(local_template_dir)
+    module_files = self.module_files(local_files, local_template_dir)
 
     managed_modules = self.managed_modules(File.join(options[:configs], options[:managed_modules_conf]),
                                            options[:filter],

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -60,7 +60,8 @@ module ModuleSync
   def self.managed_modules(config_file, filter, negative_filter)
     managed_modules = Util.parse_config(config_file)
     if managed_modules.empty?
-      puts "No modules found in #{config_file}. Check that you specified the right :configs directory and :managed_modules_conf file."
+      puts "No modules found in #{config_file}." \
+        ' Check that you specified the right :configs directory and :managed_modules_conf file.'
       exit
     end
     managed_modules.select! { |m| m =~ Regexp.new(filter) } unless filter.nil?

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -115,6 +115,7 @@ module ModuleSync
     unless options[:offline]
       Git.pull(options[:git_base], git_repo, options[:branch], options[:project_root], module_options || {})
     end
+
     module_configs = Util.parse_config(module_file(options[:project_root], namespace, module_name, MODULE_CONF_FILE))
     settings = Settings.new(defaults[GLOBAL_DEFAULTS_KEY] || {},
                             defaults,

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -43,7 +43,8 @@ module ModuleSync
                    :default => CLI.defaults[:git_base] || 'git@github.com:'
       class_option :namespace,
                    :aliases => '-n',
-                   :desc => 'Remote github namespace (user or organization) to clone from and push to. Defaults to puppetlabs',
+                   :desc => 'Remote github namespace (user or organization) to clone from and push to.' \
+                              ' Defaults to puppetlabs',
                    :default => CLI.defaults[:namespace] || 'puppetlabs'
       class_option :filter,
                    :aliases => '-f',
@@ -53,7 +54,8 @@ module ModuleSync
                    :desc => 'A regular expression to skip repositories.'
       class_option :branch,
                    :aliases => '-b',
-                   :desc => 'Branch name to make the changes in. Defaults to the default branch of the upstream repository, but falls back to "master".',
+                   :desc => 'Branch name to make the changes in.' \
+                              ' Defaults to the default branch of the upstream repository, but falls back to "master".',
                    :default => CLI.defaults[:branch]
 
       desc 'update', 'Update the modules in managed_modules.yml'
@@ -63,7 +65,8 @@ module ModuleSync
              :default => CLI.defaults[:message]
       option :configs,
              :aliases => '-c',
-             :desc => 'The local directory or remote repository to define the list of managed modules, the file templates, and the default values for template variables.'
+             :desc => 'The local directory or remote repository to define the list of managed modules,' \
+                        ' the file templates, and the default values for template variables.'
       option :remote_branch,
              :aliases => '-r',
              :desc => 'Remote branch name to push the changes to. Defaults to the branch name.',
@@ -119,13 +122,16 @@ module ModuleSync
       option :fail_on_warnings,
              :type => :boolean,
              :aliases => '-F',
-             :desc => 'Produce a failure exit code when there are warnings (only has effect when --skip_broken is enabled)',
+             :desc => 'Produce a failure exit code when there are warnings' \
+                        ' (only has effect when --skip_broken is enabled)',
              :default => false
 
       def update
         config = { :command => 'update' }.merge(options)
         config = Util.symbolize_keys(config)
-        raise Thor::Error, 'No value provided for required option "--message"' unless config[:noop] || config[:message] || config[:offline]
+        raise Thor::Error, 'No value provided for required option "--message"' unless config[:noop] \
+                                                                                      || config[:message] \
+                                                                                      || config[:offline]
         config[:git_opts] = { 'amend' => config[:amend], 'force' => config[:force] }
         ModuleSync.update(config)
       end

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe ModuleSync do
   context '::update' do
     it 'loads the managed modules from the specified :managed_modules_conf' do
-      allow(ModuleSync).to receive(:local_files).and_return([])
+      allow(ModuleSync).to receive(:find_template_files).and_return([])
       allow(ModuleSync::Util).to receive(:parse_config).with('./config_defaults.yml').and_return({})
       expect(ModuleSync).to receive(:managed_modules).with('./test_file.yml', nil, nil).and_return([])
 


### PR DESCRIPTION
I started digging into the code and trying to understand I refactored some things. These changes may assist others with similar endeavors. 

* Bring back max line length for rubocop
* use File.join() where applicable
* reuse module_file() for getting the `MODULE_CONF_FILE` (`.sync.yml`)
* renamed local_files() -> find_template_files() because it is what it does.
* rename module_files() to relative_names() because that is what it does.
* rename local variable `path` in update() to `local_template_dir` because that is what it is.