### PR TITLE
Add metadata to ERB template scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,23 @@ As mentioned, files in the moduleroot directory must be ERB templates (they must
 <%= @configs[:puppet_module] %>
 ```
 
+Alternatively some meta data is passed to the template. This will allow you to add custom Ruby extensions inside the
+template, reading other files from the module, to make the template system more adaptive.
+
+```erb
+module: <%= @metadata[:module_name] %>
+target: <%= @metadata[:target_file] %>
+workdir: <%= @metadata[:workdir] %>
+```
+
+Will result in something like:
+
+```
+module: puppet-test
+target: modules/github-org/puppet-test/test
+workdir: modules/github-org/puppet-test
+```
+
 The Templates
 -------------
 

--- a/features/update.feature
+++ b/features/update.feature
@@ -922,3 +922,36 @@ Feature: update
     When I run `msync update -m "Update Gemfile"`
     Then the exit status should be 0
     Then the output should contain "Using repository's default branch: develop"
+
+  Scenario: Adding a new file from a template using meta data
+    And a file named "config_defaults.yml" with:
+      """
+      ---
+      """
+    Given a file named "managed_modules.yml" with:
+      """
+      ---
+        - puppet-test
+      """
+    And a file named "modulesync.yml" with:
+      """
+      ---
+        namespace: maestrodev
+        git_base: https://github.com/
+      """
+    And a directory named "moduleroot"
+    And a file named "moduleroot/test.erb" with:
+      """
+      module: <%= @metadata[:module_name] %>
+      target: <%= @metadata[:target_file] %>
+      workdir: <%= @metadata[:workdir] %>
+      """
+    When I run `msync update --noop`
+    Then the exit status should be 0
+    Given I run `cat modules/maestrodev/puppet-test/test`
+    Then the output should contain:
+      """
+      module: puppet-test
+      target: modules/maestrodev/puppet-test/test
+      workdir: modules/maestrodev/puppet-test
+      """

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -4,8 +4,9 @@ require 'find'
 module ModuleSync
   module Renderer
     class ForgeModuleFile
-      def initialize(configs = {})
+      def initialize(configs = {}, metadata = {})
         @configs = configs
+        @metadata = metadata
       end
     end
 
@@ -26,8 +27,8 @@ module ModuleSync
       File.delete(file) if File.exist?(file)
     end
 
-    def self.render(_template, configs = {})
-      ForgeModuleFile.new(configs).render
+    def self.render(_template, configs = {}, metadata = {})
+      ForgeModuleFile.new(configs, metadata).render
     end
 
     def self.sync(template, target_name)


### PR DESCRIPTION
This will allow the template to be aware of the module, where the
clone is, and what the target file is.

Can be easily extended later for more data.

I use this feature outside of a usual Puppet scope, where I need to know the module name, and want to be able to detect some contents of the module.

Questions:
* Does it makes sense to you?
* Shall I update any docs or rspec tests?

## TODOs

- [x] Add a paragraph to README with some examples
- [x] Add a basic spec test that uses metadata