### PR TITLE
Fix overwriting of :global values

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -756,6 +756,9 @@ Feature: update
     And a file named "config_defaults.yml" with:
       """
       ---
+      :global:
+        global-default: some-default
+        global-to-overwrite: to-be-overwritten
       spec/spec_helper.rb:
         require:
           - puppetlabs_spec_helper/module_helper
@@ -765,6 +768,12 @@ Feature: update
       <% @configs['require'].each do |required| -%>
         require '<%= required %>'
       <% end %>
+      """
+    And a file named "moduleroot/global-test.md.erb" with:
+      """
+      <%= @configs['global-default'] %>
+      <%= @configs['global-to-overwrite'] %>
+      <%= @configs['module-default'] %>
       """
     Given I run `git init modules/maestrodev/puppet-test`
     Given a file named "modules/maestrodev/puppet-test/.git/config" with:
@@ -783,6 +792,9 @@ Feature: update
     Given a file named "modules/maestrodev/puppet-test/.sync.yml" with:
       """
       ---
+      :global:
+        global-to-overwrite: it-is-overwritten
+        module-default: some-value
       spec/spec_helper.rb:
         unmanaged: true
       """
@@ -791,6 +803,13 @@ Feature: update
     And the output should match:
       """
       Not managing spec/spec_helper.rb in puppet-test
+      """
+    Given I run `cat modules/maestrodev/puppet-test/global-test.md`
+    Then the output should match:
+      """
+      some-default
+      it-is-overwritten
+      some-value
       """
 
   Scenario: Module with custom namespace

--- a/lib/modulesync/settings.rb
+++ b/lib/modulesync/settings.rb
@@ -19,10 +19,9 @@ module ModuleSync
 
     def build_file_configs(target_name)
       file_def = lookup_config(defaults, target_name)
-      file_md  = lookup_config(module_defaults, target_name)
       file_mc  = lookup_config(module_configs, target_name)
 
-      global_defaults.merge(file_def).merge(file_md).merge(file_mc).merge(additional_settings)
+      global_defaults.merge(file_def).merge(module_defaults).merge(file_mc).merge(additional_settings)
     end
 
     def managed?(target_name)


### PR DESCRIPTION
When defining `:global` values in `.sync.yml` we faced the issue, that they were not accessible via `@configs` in the `.erb` templates.

Further debugging showed that the values were not loaded into `@configs`.

Looking at the code we found out that the values for `module_defaults` are already resolved in `modulesync.rb` (like the `global_defaults`). Therefore the additional `lookup_config` basically discards all values configured in `.sync.yml` files under `:global` as it cannot find something under the `target_name` key.