### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2019-09-19 - 1.0.0
+
+This is the first stable release! 🎉
+
+* Use namespace in directory structure when cloning repositories - [#152](https://github.com/voxpupuli/modulesync/pull/152)
+* Fix minor typo in help output - [#165](https://github.com/voxpupuli/modulesync/pull/165)
+* Small improvements and fixes - [#166](https://github.com/voxpupuli/modulesync/pull/166)
+* Fix overwriting of :global values - [#169](https://github.com/voxpupuli/modulesync/pull/169)
+
 ## 2018-12-27 - 0.10.0
 
 This is another awesome release!

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name                  = 'modulesync'
-  spec.version               = '0.10.0'
+  spec.version               = '1.0.0'
   spec.authors               = ['Vox Pupuli']
   spec.email                 = ['voxpupuli@groups.io']
   spec.summary               = 'Puppet Module Synchronizer'


### PR DESCRIPTION
We propose to make the jump to 1.0.0 since https://github.com/voxpupuli/modulesync/pull/152 introduced a substantial change in internal behavior.