### PR TITLE
Skip issuing a PR if one already exists for -b option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,7 @@ AllCops:
     - 'tmp/**/*'
     - 'pkg/**/*'
     - 'lib/monkey_patches.rb'
+    - 'spec/**/*'
 
 Style/HashSyntax:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'
-gem 'octokit', '~> 4.14'
+gem 'octokit', '~> 4.9'

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 gemspec
 
 gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'
-gem 'octokit', '~> 4.0'
+gem 'octokit', '~> 4.14'

--- a/Rakefile
+++ b/Rakefile
@@ -19,3 +19,4 @@ Cucumber::Rake::Task.new do |t|
 end
 
 task :test => %i[clean spec cucumber rubocop]
+task :default => %i[test]

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -152,7 +152,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     pull_requests = github.pull_requests(repo_path, :state => 'open', :base => 'master', :head => head)
     if pull_requests.empty?
       pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
-      $stdout.puts "Submitted PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
+      $stdout.puts "Submitted PR '#{options[:pr_title]}' to #{repo_path} - merges #{options[:branch]} into master"
     else
       $stdout.puts "Skipped! #{pull_requests.length} PRs found for branch #{options[:branch]}"
     end

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -46,7 +46,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
           .collect { |p| p.chomp('.erb') }
           .to_a
     else
-      puts "#{local_template_dir} does not exist." \
+      $stdout.puts "#{local_template_dir} does not exist." \
         ' Check that you are working in your module configs directory or' \
         ' that you have passed in the correct directory with -c.'
       exit
@@ -60,7 +60,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   def self.managed_modules(config_file, filter, negative_filter)
     managed_modules = Util.parse_config(config_file)
     if managed_modules.empty?
-      puts "No modules found in #{config_file}." \
+      $stdout.puts "No modules found in #{config_file}." \
         ' Check that you specified the right :configs directory and :managed_modules_conf file.'
       exit
     end
@@ -98,18 +98,13 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
         template = Renderer.render(erb, configs)
         Renderer.sync(template, module_file(options[:project_root], namespace, module_name, filename))
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
-        STDERR.puts "Error while rendering #{filename}"
+        $stderr.puts "Error while rendering #{filename}"
         raise
       end
     end
   end
 
   def self.manage_module(puppet_module, module_files, module_options, defaults, options)
-    if options[:pr] && !GITHUB_TOKEN
-      STDERR.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
-      raise unless options[:skip_broken]
-    end
-
     namespace, module_name = module_name(puppet_module, options[:namespace])
     git_repo = File.join(namespace, module_name)
     unless options[:offline]
@@ -125,7 +120,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
                             :git_base => options[:git_base],
                             :namespace => namespace)
     settings.unmanaged_files(module_files).each do |filename|
-      puts "Not managing #{filename} in #{module_name}"
+      $stdout.puts "Not managing #{filename} in #{module_name}"
     end
 
     files_to_manage = settings.managed_files(module_files)
@@ -143,6 +138,11 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   end
 
   def self.manage_pr(namespace, module_name, options)
+    if options[:pr] && GITHUB_TOKEN.empty?
+      $stderr.puts 'Environment variable GITHUB_TOKEN must be set to use --pr!'
+      raise unless options[:skip_broken]
+    end
+
     # We only do GitHub PR work if the GITHUB_TOKEN variable is set in the environment.
     repo_path = File.join(namespace, module_name)
     github = Octokit::Client.new(:access_token => GITHUB_TOKEN)
@@ -164,7 +164,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     # We only assign labels to the PR if we've discovered a list > 1. The labels MUST
     # already exist. We DO NOT create missing labels.
     return if pr_labels.empty?
-    puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
+    $stdout.puts "Attaching the following labels to PR #{pr['number']}: #{pr_labels.join(', ')}"
     github.add_labels_to_an_issue(repo_path, pr['number'], pr_labels)
   end
 
@@ -186,10 +186,10 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
       begin
         manage_module(puppet_module, module_files, module_options, defaults, options)
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
-        STDERR.puts "Error while updating #{puppet_module}"
+        $stderr.puts "Error while updating #{puppet_module}"
         raise unless options[:skip_broken]
         errors = true
-        puts "Skipping #{puppet_module} as update process failed"
+        $stdout.puts "Skipping #{puppet_module} as update process failed"
       end
     end
     exit 1 if errors && options[:fail_on_warnings]

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -152,12 +152,9 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     pull_requests = github.pull_requests(repo_path, :state => 'open', :base => 'master', :head => head)
     if pull_requests.empty?
       pr = github.create_pull_request(repo_path, 'master', options[:branch], options[:pr_title], options[:message])
-      puts "Submitted PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
-    elsif pull_requests.length == 1
-      pr = pull_requests.pop
-      puts "Skipped! PR '#{pr['title']}' already exists! See #{pr['html_url']}"
+      $stdout.puts "Submitted PR '#{options[:pr_title]}' on GitHub to #{repo_path} - merges #{options[:branch]} into master"
     else
-      puts "Skipped! #{pull_requests.length} PRs found for branch #{options[:branch]}"
+      $stdout.puts "Skipped! #{pull_requests.length} PRs found for branch #{options[:branch]}"
     end
 
     # PR labels can either be a list in the YAML file or they can pass in a comma

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -37,7 +37,7 @@ describe ModuleSync do
         "number" => "44"
       }
 
-      allow(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([pr])
+      expect(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([pr])
       expect { ModuleSync.manage_pr(@namespace, @repo_name, @options) }.to output(/Skipped! 1 PRs found for branch test/).to_stdout
     end
   end

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -11,4 +11,34 @@ describe ModuleSync do
       ModuleSync.update(options)
     end
   end
+
+  context '::manage_pr' do
+    before(:each) do
+      stub_const('GITHUB_TOKEN', 'test')
+      @git_repo = 'test/modulesync'
+      @namespace, @repo_name = @git_repo.split('/')
+      @options = {
+        :pr => true,
+        :pr_title => 'Test PR is submitted',
+        :branch => 'test',
+        :message => 'Hello world',
+        :pr_auto_merge => false,
+      }
+
+      @client = double()
+    end
+
+    it 'skips submitting PR if one has already been issued' do
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+
+      pr = {
+        "title" => "Test title",
+        "html_url" => "https://example.com/pulls/44",
+        "number" => "44"
+      }
+
+      allow(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([pr])
+      expect { ModuleSync.manage_pr(@namespace, @repo_name, @options) }.to output(/Skipped! 1 PRs found for branch test/).to_stdout
+    end
+  end
 end

--- a/spec/unit/modulesync_spec.rb
+++ b/spec/unit/modulesync_spec.rb
@@ -28,6 +28,20 @@ describe ModuleSync do
       @client = double()
     end
 
+    it 'rasies an error when GITHUB_TOKEN not set for PRs' do
+      stub_const('GITHUB_TOKEN', '')
+      options = {:pr => true, :skip_broken => false}
+
+      expect { ModuleSync.manage_pr(@namespace, @repo_name, options) }.to raise_error(RuntimeError).and output(/GITHUB_TOKEN/).to_stderr
+    end
+
+    it 'submits PR when --pr is set' do
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+      allow(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([])
+      expect(@client).to receive(:create_pull_request).with(@git_repo, 'master', @options[:branch], @options[:pr_title], @options[:message]).and_return({"html_url" => "http://example.com/pulls/22"})
+      expect { ModuleSync.manage_pr(@namespace, @repo_name, @options) }.to output(/Submitted PR/).to_stdout
+    end
+
     it 'skips submitting PR if one has already been issued' do
       allow(Octokit::Client).to receive(:new).and_return(@client)
 
@@ -39,6 +53,17 @@ describe ModuleSync do
 
       expect(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([pr])
       expect { ModuleSync.manage_pr(@namespace, @repo_name, @options) }.to output(/Skipped! 1 PRs found for branch test/).to_stdout
+    end
+
+    it 'adds labels to PR when --pr-labels is set' do
+      @options[:pr_labels] = "HELLO,WORLD"
+
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+      allow(@client).to receive(:create_pull_request).and_return({"html_url" => "http://example.com/pulls/22", "number" => "44"})
+      allow(@client).to receive(:pull_requests).with(@git_repo, :state => 'open', :base => 'master', :head => "#{@namespace}:#{@options[:branch]}").and_return([])
+
+      expect(@client).to receive(:add_labels_to_an_issue).with(@git_repo, "44", ["HELLO", "WORLD"])
+      expect { ModuleSync.manage_pr(@namespace, @repo_name, @options) }.to output(/Attaching the following labels to PR 44: HELLO, WORLD/).to_stdout
     end
   end
 end


### PR DESCRIPTION
* This checks for an existing PR for `head` into `base`. If a PR exists, we skip issuing the PR. Cleans up the code to comply with Rubocop.
* Adds full test coverage for the `manage_pr` method.
* Adds a default task for `rake`.
* Switches output over to `$stdout` and `$stderr`.