### PR TITLE
Allow absolute path for config files

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -134,9 +134,13 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  def config_path(file, options)
+  def self.config_path(file, options)
     return file if Pathname.new(file).absolute?
     File.join(options[:configs], file)
+  end
+
+  def config_path(file, options)
+    self.class.config_path(file, options)
   end
 
   def self.update(options)

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -135,11 +135,8 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   end
 
   def config_path(file, options)
-    if Pathname.new(file).absolute?
-      file
-    else
-      File.join(options[:configs], file)
-    end
+    return file if Pathname.new(file).absolute?
+    File.join(options[:configs], file)
   end
 
   def self.update(options)

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -134,9 +134,17 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     end
   end
 
+  def config_path(file, options)
+    if Pathname.new(file).absolute?
+      file
+    else
+      File.join(options[:configs], file)
+    end
+  end
+
   def self.update(options)
     options = config_defaults.merge(options)
-    defaults = Util.parse_config(File.join(options[:configs], CONF_FILE))
+    defaults = Util.parse_config(config_path(CONF_FILE, options))
     if options[:pr]
       unless options[:branch]
         $stderr.puts 'A branch must be specified with --branch to use --pr!'
@@ -146,11 +154,11 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
       @pr = create_pr_manager if options[:pr]
     end
 
-    local_template_dir = File.join(options[:configs], MODULE_FILES_DIR)
+    local_template_dir = config_path(MODULE_FILES_DIR, options)
     local_files = find_template_files(local_template_dir)
     module_files = relative_names(local_files, local_template_dir)
 
-    managed_modules = self.managed_modules(File.join(options[:configs], options[:managed_modules_conf]),
+    managed_modules = self.managed_modules(config_path(options[:managed_modules_conf], options),
                                            options[:filter],
                                            options[:negative_filter])
 


### PR DESCRIPTION
This PR makes it possible to pass configuration as absolute file names instead of relative.

This will allow to pass `managed_modules_conf` from a tempfile for example (to secure possible tokens in there).