### PR TITLE
Symbolize keys in managed_modules except for module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,14 +197,14 @@ For GitHub Enterprise and self-hosted GitLab instances you also need to set the
 ```yaml
 ---
 repo1:
-  :github:
-    :token: 'EXAMPLE_TOKEN'
-    :base_url: 'https://api.github.com/'
+  github:
+    token: 'EXAMPLE_TOKEN'
+    base_url: 'https://api.github.com/'
 
 repo2:
-  :gitlab:
-    :token: 'EXAMPLE_TOKEN'
-    :base_url: 'https://git.example.com/api/v4'
+  gitlab:
+    token: 'EXAMPLE_TOKEN'
+    base_url: 'https://git.example.com/api/v4'
 ```
 
 Then:

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -171,7 +171,8 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     # managed_modules is either an array or a hash
     managed_modules.each do |puppet_module, module_options|
       begin
-        manage_module(puppet_module, module_files, module_options, defaults, options)
+        mod_options = module_options.nil? ? nil : Util.symbolize_keys(module_options)
+        manage_module(puppet_module, module_files, mod_options, defaults, options)
       rescue # rubocop:disable Lint/RescueWithoutErrorClass
         $stderr.puts "Error while updating #{puppet_module}"
         raise unless options[:skip_broken]

--- a/lib/modulesync/util.rb
+++ b/lib/modulesync/util.rb
@@ -3,7 +3,10 @@ require 'yaml'
 module ModuleSync
   module Util
     def self.symbolize_keys(hash)
-      hash.inject({}) { |memo, (k, v)| memo[k.to_sym] = v; memo }
+      hash.inject({}) do |memo, (k, v)|
+        memo[k.to_sym] = v.is_a?(Hash) ? symbolize_keys(v) : v
+        memo
+      end
     end
 
     def self.parse_config(config_file)


### PR DESCRIPTION
This allows to use symbols or strings for subkeys


Properly fixes #167 and #157 