### PR TITLE
Drop Ruby 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 dist: trusty
 script: 'bundle exec rake test'
 rvm:
-  - 2.0
   - 2.1
   - 2.2
   - 2.3

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-gem 'cucumber', '< 3.0' if RUBY_VERSION < '2.1'
 gem 'octokit', '~> 4.9'


### PR DESCRIPTION
Ruby 2.0 is EoL since a long long time and the gem dependencies don't
resolve anymore.