### PR TITLE
Fix language-dependent Git output handling

### DIFF
--- a/lib/monkey_patches.rb
+++ b/lib/monkey_patches.rb
@@ -38,7 +38,20 @@ module Git
     end
   end
 
+  module LibMonkeyPatch
+    # Monkey patch set_custom_git_env_variables due to our ::Git::GitExecuteError handling.
+    #
+    # We rescue on the GitExecuteError and proceed differently based on the output of git.
+    # This way makes code language-dependent, so here we ensure that Git gem throw git commands with the "C" language
+    def set_custom_git_env_variables
+      super
+      ENV['LANG'] = 'C.UTF-8'
+    end
+  end
+
   class Lib
+    prepend LibMonkeyPatch
+
     # Monkey patch ls_files until https://github.com/ruby-git/ruby-git/pull/320 is resolved
     def ls_files(location=nil)
       location ||= '.'


### PR DESCRIPTION
When running `msync` on a system configured with a different language than english, some errors catch fail.

This PR fixes #85 