### PR TITLE
Minor modernization and cosmetic fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.4
   Exclude:
     - 'vendor/**/*'
     - 'tmp/**/*'
@@ -25,3 +25,6 @@ Layout/IndentHeredoc:
 # sane line length
 Metrics/LineLength:
   Max: 120
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/features/step_definitions/git_steps.rb
+++ b/features/step_definitions/git_steps.rb
@@ -16,11 +16,11 @@ Given 'a remote module repository' do
         - puppet-test
       """
   )
-  write_file('modulesync.yml', <<-CONFIG)
----
-  namespace: sources
-  git_base: file://#{expand_path('.')}/
-  CONFIG
+  write_file('modulesync.yml', <<~CONFIG)
+    ---
+    namespace: sources
+    git_base: file://#{expand_path('.')}/
+    CONFIG
 end
 
 Given Regexp.new(/a remote module repository with "(.+?)" as the default branch/) do |branch|
@@ -33,11 +33,12 @@ Given Regexp.new(/a remote module repository with "(.+?)" as the default branch/
         - puppet-test
       """
   )
-  write_file('modulesync.yml', <<-CONFIG)
----
-  namespace: sources
-  git_base: file://#{expand_path('.')}/
-  CONFIG
+  write_file('modulesync.yml', <<~CONFIG)
+    ---
+    namespace: sources
+    git_base: file://#{expand_path('.')}/
+    CONFIG
+
   cd('sources/puppet-test') do
     steps %(
       And I run `git branch -M master #{branch}`

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -36,15 +36,14 @@ module ModuleSync
     class Base < Thor
       class_option :project_root,
                    :aliases => '-c',
-                   :desc => 'Path used by git to clone modules into. Defaults to "modules"',
+                   :desc => 'Path used by git to clone modules into.',
                    :default => CLI.defaults[:project_root] || 'modules'
       class_option :git_base,
                    :desc => 'Specify the base part of a git URL to pull from',
                    :default => CLI.defaults[:git_base] || 'git@github.com:'
       class_option :namespace,
                    :aliases => '-n',
-                   :desc => 'Remote github namespace (user or organization) to clone from and push to.' \
-                              ' Defaults to puppetlabs',
+                   :desc => 'Remote github namespace (user or organization) to clone from and push to.',
                    :default => CLI.defaults[:namespace] || 'puppetlabs'
       class_option :filter,
                    :aliases => '-f',

--- a/lib/modulesync/git.rb
+++ b/lib/modulesync/git.rb
@@ -150,7 +150,7 @@ module ModuleSync
           tag(repo, new, options[:tag_pattern]) if options[:tag]
         end
       rescue ::Git::GitExecuteError => git_error
-        if git_error.message =~ /working (directory|tree) clean/
+        if git_error.message.match?(/working (directory|tree) clean/)
           puts "There were no files to update in #{name}. Not committing."
           return false
         else


### PR DESCRIPTION
During the work on #199, I found few minor things that can be improve right now without waiting the end on the work.

On the way, I already provided #200 and now:
I bump the target ruby version of `rubocop` to 2.4 (the last supported by `rubocop` 0.50.0) in order to allow squiggly heredoc syntax.
Please note I want to provide more further patches to support a recent `rubocop` version, but it implies massive changes, so I choose to make one small step first and keep changes in #199 comprehensive.

This PR also contains a minor cosmetic change on CLI help, where some defaults where shown twice.