### PR TITLE
Rework exception handling

### DIFF
--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -120,13 +120,10 @@ module ModuleSync
           repo.push('origin', branch, opts_push)
         end
       rescue Git::GitExecuteError => e
-        if e.message.match?(/working (directory|tree) clean/)
-          puts "There were no changes in '#{@directory}'. Not committing."
-          return false
-        else
-          puts e
-          raise
-        end
+        raise unless e.message.match?(/working (directory|tree) clean/)
+
+        puts "There were no changes in '#{@directory}'. Not committing."
+        return false
       end
 
       true


### PR DESCRIPTION
This commit gives the user a better output message:
- it uses the exception message if available or fallback on the "Error during update" message
- it prefixes the message by the current module name

This commits introduces a ModuleSync::Error that will be used to raise
exceptions, with a message outputed on stderr, but without a full
backtrace, useless for user.

It keeps the current behavior when error (ie. StandardError) comes from
templates (ie. ERB) rendering as user may need to see why the rendering
failed.

Git::GitExecuteError backtraces are now hidden too: user needs
to understand what happends, with the error message, but not where error
occured.