### PR TITLE
Deal with nil branch

### DIFF
--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -39,6 +39,9 @@ module ModuleSync
     def switch_branch(branch)
       unless branch
         branch = default_branch
+        unless branch
+          raise "Unable to detect default branch"
+        end
         puts "Using repository's default branch: #{branch}"
       end
       return if repo.current_branch == branch


### PR DESCRIPTION
default_branch doesn't guarantee a result. This checks for the nil value and raises an exception.

This is probably not a good way to deal with it, but it's a lot clearer for the user. I happened to run into this because I didn't have a HEAD for the remote `origin` so `rm .git/refs/remotes/origin/HEAD` is the reproducer.