### PR TITLE
Fix support of repos without a 'master' branch

### DIFF
--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -51,7 +51,11 @@ module ModuleSync
         repo.checkout("origin/#{branch}")
         repo.branch(branch).checkout
       else
-        repo.checkout('origin/master')
+        if remote_branch_exists?('main')
+          repo.checkout('origin/main')
+        else
+          repo.checkout('origin/master')
+        end
         puts "Creating new branch #{branch}"
         repo.branch(branch).checkout
       end


### PR DESCRIPTION
When the target branch does not exist either remotely or locally, the
code checkouts the 'master' branch before branching.  Recently, a number
of projects have switched from naming their main branch 'master' to
'main', and these projects may not have a 'master' branch anymore.  In
such a situation, modulesync failed.

When we are in such a situation, check for a 'main' branch, and if it
exist use this one; otherwise fallback to the previous default of
'master'.