### PR TITLE
Fix condition for triggering the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  create:
-    ref_type: tag
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
The previous construct does not appear to be something documented in the [Workflow syntax for GitHub Actions `on`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on), and searching `ref_type` does not return any documentation, so prefer the syntax used for publishing the modules on the Puppet forge.