### PR TITLE
Properly ensure the parent directory exists

### DIFF
--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -32,8 +32,7 @@ module ModuleSync
     end
 
     def self.sync(template, target_name)
-      path = target_name.rpartition('/').first
-      FileUtils.mkdir_p(path) unless path.empty?
+      FileUtils.mkdir_p(File.dirname(target_name))
       File.write(target_name, template)
     end
   end


### PR DESCRIPTION
Rather than splitting the filename on a / this uses File.dirname.