### PR TITLE
CLI: Show relevant help when using --help option on a subcommand

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -20,6 +20,14 @@ Feature: CLI
     When I successfully run `msync help`
     Then the output should match /Commands:/
 
+  Scenario: Use --help options on subcommand should show subcommand help
+    When I successfully run `msync clone --help`
+    Then the output should contain:
+    """
+    Usage:
+      msync clone
+    """
+
   Scenario: When overriding a setting from the config file on the command line
     Given a puppet module "puppet-test" from "fakenamespace"
     And a file named "managed_modules.yml" with:

--- a/lib/modulesync/cli/thor.rb
+++ b/lib/modulesync/cli/thor.rb
@@ -8,7 +8,19 @@ module ModuleSync
     # This class extends ::Thor class to
     # - exit with status code sets to `1` on Thor failure (e.g. missing required option)
     # - exit with status code sets to `1` when user calls `msync` (or a subcommand) without required arguments
+    # - show subcommands help using `msync subcommand --help`
     class Thor < ::Thor
+      def self.start(*args)
+        if (Thor::HELP_MAPPINGS & ARGV).any? && subcommands.none? { |command| command.start_with?(ARGV[0]) }
+          Thor::HELP_MAPPINGS.each do |cmd|
+            if (match = ARGV.delete(cmd))
+              ARGV.unshift match
+            end
+          end
+        end
+        super
+      end
+
       desc '_invalid_command_call', 'Invalid command', hide: true
       def _invalid_command_call
         self.class.new.help


### PR DESCRIPTION
A tiny PR to (again) workaround a strange behavior of `thor`...

This one allow to use `msync subcommand --help` to show the subcommand help.

@smortex : You should like this one ;-)