### PR TITLE
exec command: Only switch branch when cloning

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -199,8 +199,12 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
     managed_modules.each do |puppet_module|
       $stdout.puts "#{puppet_module.given_name}:"
 
-      puppet_module.repository.clone unless puppet_module.repository.cloned?
-      puppet_module.repository.switch branch: @options[:branch]
+      if puppet_module.repository.cloned?
+        puppet_module.repository.switch branch: @options[:branch] if @options[:branch]
+      else
+        puppet_module.repository.clone
+        puppet_module.repository.switch branch: @options[:branch]
+      end
 
       command_args = cli_options[:command_args]
       local_script = File.expand_path command_args[0]


### PR DESCRIPTION
When using msync exec, I was surprised to learn it switched branches. My immediate impression was that it was simply a wrapper that executes commands on checkouts.

This changes the commend to only switch branch when cloning the repository or when it's explicitly passed via the --branch option.

Right now there are no tests (I did verify it manually) because I first want to figure out if this is a good idea. @smortex would you mind having a look?