### PR TITLE
Handle Ruby 3.1 ERB trim_mode deprecation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
     - 'Gemfile'
     - 'Rakefile'
 
+Style/FetchEnvVar:
+  Enabled: false
+
 Style/HashSyntax:
   Enabled: false
 

--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -17,7 +17,12 @@ module ModuleSync
                       else
                         "#{target_name}.erb"
                       end
-      erb_obj = ERB.new(File.read(template_file), nil, '-')
+      template = File.read(template_file)
+      erb_obj = if RUBY_VERSION >= '2.7'
+                  ERB.new(template, trim_mode: '-')
+                else
+                  ERB.new(template, nil, '-')
+                end
       erb_obj.filename = template_file
       erb_obj.def_method(ForgeModuleFile, 'render()', template_file)
       erb_obj


### PR DESCRIPTION
In Ruby 3.1 using `trim_mode` must be passed as a keyword argument or a deprecation warning is shown. However, that is only possible on Ruby 2.7 or newer.