### PR TITLE
Expose namespace in metadata

### DIFF
--- a/features/update.feature
+++ b/features/update.feature
@@ -717,6 +717,7 @@ Feature: update
     And a file named "moduleroot/test.erb" with:
       """
       module: <%= @metadata[:module_name] %>
+      namespace: <%= @metadata[:namespace] %>
       target: <%= @metadata[:target_file] %>
       workdir: <%= @metadata[:workdir] %>
       """
@@ -724,6 +725,7 @@ Feature: update
     Then the file named "modules/fakenamespace/puppet-test/test" should contain:
       """
       module: puppet-test
+      namespace: fakenamespace
       target: modules/fakenamespace/puppet-test/test
       workdir: modules/fakenamespace/puppet-test
       """

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -83,7 +83,6 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
   end
 
   def self.manage_file(puppet_module, filename, settings, options)
-    module_name = settings.additional_settings[:puppet_module]
     configs = settings.build_file_configs(filename)
     target_file = puppet_module.path(filename)
     if configs['delete']
@@ -94,7 +93,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
         erb = Renderer.build(templatename)
         # Meta data passed to the template as @metadata[:name]
         metadata = {
-          :module_name => module_name,
+          :module_name => settings.additional_settings[:puppet_module],
           :namespace => settings.additional_settings[:namespace],
           :workdir => puppet_module.working_directory,
           :target_file => target_file,

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -95,6 +95,7 @@ module ModuleSync # rubocop:disable Metrics/ModuleLength
         # Meta data passed to the template as @metadata[:name]
         metadata = {
           :module_name => module_name,
+          :namespace => settings.additional_settings[:namespace],
           :workdir => puppet_module.working_directory,
           :target_file => target_file,
         }


### PR DESCRIPTION
While the namespace is already in @configs, it feels more natural in metadata.