### PR TITLE
Fix compatibility with latest `ruby-git`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,7 @@ Style/FrozenStringLiteralComment:
 # We explicitly prefer $stderr.puts over #warn
 Style/StderrPuts:
   Enabled: false
+
+# Disabling until there's a consensus on what the default style should be
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/features/update/pull_request.feature
+++ b/features/update/pull_request.feature
@@ -32,9 +32,8 @@ Feature: Create a pull-request/merge-request after update
       """
       ---
       puppet-test:
-        gitlab: {
+        gitlab:
           base_url: 'https://gitlab.example.com'
-      }
       """
     And I set the environment variables to:
       | variable     | value  |
@@ -60,9 +59,8 @@ Feature: Create a pull-request/merge-request after update
       """
       ---
       puppet-test:
-        gitlab: {
+        gitlab:
           base_url: 'https://gitlab.example.com'
-        }
       """
     And I set the environment variables to:
       | variable     | value  |
@@ -77,9 +75,8 @@ Feature: Create a pull-request/merge-request after update
       """
       ---
       puppet-test:
-        gitlab: {
+        gitlab:
           base_url: https://gitlab.example.com
-        }
       """
     And a file named "config_defaults.yml" with:
       """

--- a/lib/modulesync/git_service/github.rb
+++ b/lib/modulesync/git_service/github.rb
@@ -22,9 +22,8 @@ module ModuleSync
         head = "#{namespace}:#{source_branch}"
 
         if noop
-          $stdout.puts \
-            "Using no-op. Would submit PR '#{title}' to '#{repo_path}' " \
-            "- merges '#{source_branch}' into '#{target_branch}'"
+          $stdout.puts "Using no-op. Would submit PR '#{title}' to '#{repo_path}' " \
+                       "- merges '#{source_branch}' into '#{target_branch}'"
           return
         end
 

--- a/lib/modulesync/git_service/gitlab.rb
+++ b/lib/modulesync/git_service/gitlab.rb
@@ -28,9 +28,8 @@ module ModuleSync
 
       def _open_pull_request(repo_path:, namespace:, title:, message:, source_branch:, target_branch:, labels:, noop:) # rubocop:disable Metrics/ParameterLists, Lint/UnusedMethodArgument
         if noop
-          $stdout.puts \
-            "Using no-op. Would submit MR '#{title}' to '#{repo_path}' " \
-            "- merges #{source_branch} into #{target_branch}"
+          $stdout.puts "Using no-op. Would submit MR '#{title}' to '#{repo_path}' " \
+                       "- merges #{source_branch} into #{target_branch}"
           return
         end
 

--- a/lib/modulesync/hook.rb
+++ b/lib/modulesync/hook.rb
@@ -15,10 +15,10 @@ module ModuleSync
       <<~CONTENT
         #!/usr/bin/env bash
 
-        current_branch=\`git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,'\`
-        git_dir=\`git rev-parse --show-toplevel\`
-        message=\`git log -1 --format=%B\`
-        msync -m "\$message" #{arguments}
+        current_branch=`git symbolic-ref HEAD | sed -e 's,.*/(.*),\1,'`
+        git_dir=`git rev-parse --show-toplevel`
+        message=`git log -1 --format=%B`
+        msync -m "$message" #{arguments}
       CONTENT
     end
 

--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -31,6 +31,9 @@ module ModuleSync
     end
 
     def default_branch
+      # `Git.default_branch` requires ruby-git >= 1.17.0
+      return Git.default_branch(repo.dir) if Git.respond_to? :default_branch
+
       symbolic_ref = repo.branches.find { |b| b.full.include?('remotes/origin/HEAD') }
       return unless symbolic_ref
 

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'aruba', '>= 0.14', '< 2'
+  spec.add_development_dependency 'aruba', '~>2.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'cucumber'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Since `ruby-git` `1.16.0` it is no longer possible to parse the output of `branch.full` to determine the default branch. (It now only returns `"remotes/origin/HEAD"` where previously it returned `"remotes/origin/HEAD -> origin/master"`)

Fortunately, since `1.17.0` (which was only released a couple of days after `1.16.0`), there is a `Git.default_branch` method we can use instead.

This commit uses the new method if available.  In the future, we can probably drop the old code and require `ruby-git` `>= 1.17.0`, but since the project seems to currently be undergoing quite a bit of development and we might encounter other issues, lets keep it in for now.

Fixes #259