### PR TITLE
Clean up redundant statement

### DIFF
--- a/lib/modulesync/renderer.rb
+++ b/lib/modulesync/renderer.rb
@@ -12,11 +12,7 @@ module ModuleSync
 
     def self.build(template_file)
       template = File.read(template_file)
-      erb_obj = if RUBY_VERSION >= '2.7'
-                  ERB.new(template, trim_mode: '-')
-                else
-                  ERB.new(template, trim_mode: '-')
-                end
+      erb_obj = ERB.new(template, trim_mode: '-')
       erb_obj.filename = template_file
       erb_obj.def_method(ForgeModuleFile, 'render()', template_file)
       erb_obj


### PR DESCRIPTION
In ee8623c53926b6cce7e6387438ad43901e609290 the support for old versions was dropped, but this resulted in an if statement with the same code in both branches.

Fixes: ee8623c53926 ("Drop EoL Ruby 2.5/2.6 support")