### PR TITLE
pin thor to 1.3.0

### DIFF
--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'gitlab', '~>4.0'
   spec.add_runtime_dependency 'octokit', '>=4', '<9'
   spec.add_runtime_dependency 'puppet-blacksmith', '>= 3.0', '< 8'
-  spec.add_runtime_dependency 'thor'
+  spec.add_runtime_dependency 'thor', '1.3.0'
 end


### PR DESCRIPTION
With thor 1.3.1 we've two failing tests:

```
Failing Scenarios:
cucumber features/execute.feature:36 # Scenario: Show fail-fast default value in help
cucumber features/execute.feature:44 # Scenario: Override fail-fast default value using config file
```

as a workaround to get CI green again we'r pinning to 1.3.0. I think the bug is fixed in https://github.com/rails/thor/pull/878 but not yet released.