### PR TITLE
Add a flag to `msync execute` on the default branch

### DIFF
--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -209,7 +209,11 @@ module ModuleSync
       $stdout.puts "#{puppet_module.given_name}:"
 
       puppet_module.repository.clone unless puppet_module.repository.cloned?
-      puppet_module.repository.switch branch: @options[:branch]
+      if @options[:default_branch]
+        puppet_module.repository.switch branch: false
+      else
+        puppet_module.repository.switch branch: @options[:branch]
+      end
 
       command_args = cli_options[:command_args]
       local_script = File.expand_path command_args[0]

--- a/lib/modulesync/cli.rb
+++ b/lib/modulesync/cli.rb
@@ -175,6 +175,11 @@ module ModuleSync
              aliases: '-b',
              desc: 'Branch name to make the changes in.',
              default: CLI.defaults[:branch]
+      option :default_branch,
+             aliases: '-B',
+             type: :boolean,
+             desc: 'Work on the default branch (take precedence over --branch).',
+             default: false
       option :fail_fast,
              type: :boolean,
              desc: 'Abort the run after a command execution failure',


### PR DESCRIPTION
From time to time, it makes sense to ensure we have a clean environment
to work on and synchronize the module repositories with what is
available on the remote end to do some local cleanup.

By default we work on what is configured in modulesync_config's default
branch (usualy a branch named "modulesync"), but for running `git pull`
we want to be on the default branch, which may be named 'main' or
'master' depending on the repository.  Using `--branch main` or
`--branch master` will not have the expected outcome.

Add a `--default-branch` / `-B` flag to indicate that we want to work on
the default branch of the module.

This allows one to do some cleanup with:

```
bundle exec msync execute --default-branch -- git pull
bundle exec msync execute --default-branch -- git fetch --prune
bundle exec msync execute --default-branch -- git reset --hard
```

This is hopefully more convenient than removing the whole `modules`
directory and fetching all modules again.
