### PR TITLE
gemspec: allow puppet-blacksmith 8.x

### DIFF
--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'git', '~>1.7'
   spec.add_runtime_dependency 'gitlab', '>=4', '<6'
   spec.add_runtime_dependency 'octokit', '>=4', '<10'
-  spec.add_runtime_dependency 'puppet-blacksmith', '>= 3.0', '< 8'
+  spec.add_runtime_dependency 'puppet-blacksmith', '>= 3.0', '< 9'
   spec.add_runtime_dependency 'thor', '1.3.0'
 end


### PR DESCRIPTION
This should allow (at least partially) for Ruby 3.4 support, which was added in puppet-blacksmith 8.1.0.