### PR TITLE
Execute pre_commit_script as a complete path

### DIFF
--- a/contrib/openstack-commit-msg-hook.sh
+++ b/contrib/openstack-commit-msg-hook.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-commit_msg_path=$1/.git/hooks/commit-msg
-
-if [ ! -f $commit_msg_path ]; then
-  curl -s -Lo $commit_msg_path http://review.openstack.org/tools/hooks/commit-msg
-  chmod 775 $commit_msg_path
-fi

--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -145,8 +145,7 @@ module ModuleSync
         opts_commit = { amend: true } if options[:amend]
         opts_push = { force: true } if options[:force]
         if options[:pre_commit_script]
-          script = "#{File.dirname(File.dirname(__FILE__))}/../contrib/#{options[:pre_commit_script]}"
-          `#{script} #{@directory}`
+          system(options[:pre_commit_script], @directory)
         end
         repo.commit(message, opts_commit)
         if options[:remote_branch]


### PR DESCRIPTION
Prior to this the pre_commit_script needed to be in contrib, as shipped by the gem. This gives complete freedom on what to run, which gives a lot more freedom.

Currently untested, but @TheMeier recently did a work on cleaning up fixture files. This would allow creating a script that does all the clean ups on every modulesync, and more.