### PR TITLE
thor: allow 1.4

### DIFF
--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -28,7 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gitlab', '>=4', '<6'
   spec.add_dependency 'octokit', '>=4', '<10'
   spec.add_dependency 'puppet-blacksmith', '>= 3.0', '< 9'
-  # 1.3.1 has a bug that was fixed in 1.3.2 https://github.com/rails/thor/pull/878
-  # Allow 1.2 and newer, because Perforce facter 4.10.0 only allows < 1.3....
-  spec.add_dependency 'thor', '~> 1.2', '!= 1.3.1'
+  spec.add_dependency 'thor', '~> 1.4'
 end


### PR DESCRIPTION
Allowing 1.4 resolves a security issue in Thor:

* https://github.com/voxpupuli/modulesync/security/dependabot/1
* https://github.com/rails/thor/pull/897

We shouldn't need to support ancient Perforce facter anymore.
