### PR TITLE
Drop ruby older than 3.2.0

### DIFF
--- a/lib/modulesync/cli/thor.rb
+++ b/lib/modulesync/cli/thor.rb
@@ -13,7 +13,7 @@ module ModuleSync
     # - show subcommands help using `msync subcommand --help`
     class Thor < ::Thor
       def self.start(*args)
-        if (Thor::HELP_MAPPINGS & ARGV).any? && subcommands.none? { |command| command.start_with?(ARGV[0]) }
+        if Thor::HELP_MAPPINGS.intersect?(ARGV) && subcommands.none? { |command| command.start_with?(ARGV[0]) }
           Thor::HELP_MAPPINGS.each do |cmd|
             if (match = ARGV.delete(cmd))
               ARGV.unshift match

--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -145,7 +145,7 @@ module ModuleSync
         opts_commit = { amend: true } if options[:amend]
         opts_push = { force: true } if options[:force]
         if options[:pre_commit_script]
-          script = "#{File.dirname(File.dirname(__FILE__))}/../contrib/#{options[:pre_commit_script]}"
+          script = "#{File.dirname(__FILE__, 2)}/../contrib/#{options[:pre_commit_script]}"
           `#{script} #{@directory}`
         end
         repo.commit(message, opts_commit)

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description           = 'Utility to synchronize common files across puppet modules in Github.'
   spec.homepage              = 'https://github.com/voxpupuli/modulesync'
   spec.license               = 'Apache-2.0'
-  spec.required_ruby_version = '>= 2.7.0'
+  spec.required_ruby_version = '>= 3.1.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'cucumber', '~> 9.2'
   spec.add_development_dependency 'rake', '~> 13.2', '>= 13.2.1'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  spec.add_development_dependency 'voxpupuli-rubocop', '~> 3.1.0'
+  spec.add_development_dependency 'voxpupuli-rubocop', '~> 4.1.0'
 
   spec.add_dependency 'git', '~>1.7'
   spec.add_dependency 'gitlab', '>=4', '<6'


### PR DESCRIPTION
Changing minimum from 2.7.0 to 3.2.0

With removal of Puppet 7 maintaining older ruby support is not desirable.