### PR TITLE
fix: validate PR credentials and retry PR creation

### DIFF
--- a/features/update/pull_request.feature
+++ b/features/update/pull_request.feature
@@ -88,7 +88,7 @@ Feature: Create a pull-request/merge-request after update
       """
       <%= @configs['name'] %>
       """
-    When I run `msync update --noop --pr`
+    When I run `msync update --message "Update test" --pr`
     Then the stderr should contain "A token is required to use services from gitlab"
     And the exit status should be 1
     And the puppet module "puppet-test" from "fakenamespace" should have no commits made by "Aruba"

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -152,7 +152,7 @@ module ModuleSync
         new = puppet_module.bump(options[:message], options[:changelog])
         puppet_module.repository.tag(new, options[:tag_pattern]) if options[:tag]
       end
-      pushed && options[:pr] && puppet_module.open_pull_request
+      options[:pr] && (pushed || puppet_module.pull_request_branch_ready?) && puppet_module.open_pull_request
     end
   end
 
@@ -174,9 +174,13 @@ module ModuleSync
     local_files = find_template_files(local_template_dir)
     module_files = relative_names(local_files, local_template_dir)
 
+    # Initialize every Git service before updating any repository.
+    # This validates PR credentials before an update can commit or push changes.
+    initialized_modules = managed_modules
+    initialized_modules.each(&:git_service) if options[:pr]
+
     errors = false
-    # managed_modules is either an array or a hash
-    managed_modules.each do |puppet_module|
+    initialized_modules.each do |puppet_module|
       manage_module(puppet_module, module_files, defaults)
     rescue ModuleSync::Error, Git::Error => e
       message = e.message || 'Error during `update`'

--- a/lib/modulesync/repository.rb
+++ b/lib/modulesync/repository.rb
@@ -32,6 +32,16 @@ module ModuleSync
         repo.diff("#{local_branch}..origin/#{remote_branch}").any?
     end
 
+    # This method checks if the source branch is ahead of the target branch in the remote repository.
+    # It does this by checking if there are any commits in the source branch that are not in the target branch.
+    def remote_branch_ahead?(source_branch, target_branch)
+      return false unless remote_branch_exists?(source_branch) && remote_branch_exists?(target_branch)
+
+      log = repo.log(1).between("origin/#{target_branch}", "origin/#{source_branch}")
+      commits = log.respond_to?(:execute) ? log.execute : log
+      commits.any?
+    end
+
     def default_branch
       # `Git.default_branch` requires ruby-git >= 1.17.0
       return Git.default_branch(repo.dir) if Git.respond_to? :default_branch

--- a/lib/modulesync/source_code.rb
+++ b/lib/modulesync/source_code.rb
@@ -68,11 +68,29 @@ module ModuleSync
         namespace: repository_namespace,
         title: ModuleSync.options[:pr_title],
         message: ModuleSync.options[:message],
-        source_branch: ModuleSync.options[:remote_branch] || ModuleSync.options[:branch] || repository.default_branch,
-        target_branch: ModuleSync.options[:pr_target_branch] || repository.default_branch,
+        source_branch: pull_request_source_branch,
+        target_branch: pull_request_target_branch,
         labels: ModuleSync::Util.parse_list(ModuleSync.options[:pr_labels]),
         noop: ModuleSync.options[:noop],
       )
+    end
+
+    # This method checks if the pull request branch is ready to be opened.
+    # It does this by checking if the source branch is ahead of the target branch in the remote repository.
+    def pull_request_branch_ready?
+      repository.remote_branch_ahead?(pull_request_source_branch, pull_request_target_branch)
+    end
+
+    # This method returns the source branch for the pull request.
+    # It first checks if the `remote_branch` option is set, then checks if the `branch` option is set, and finally defaults to the repository's default branch.
+    def pull_request_source_branch
+      ModuleSync.options[:remote_branch] || ModuleSync.options[:branch] || repository.default_branch
+    end
+
+    # This method returns the target branch for the pull request.
+    # It first checks if the `pr_target_branch` option is set, and if not, it defaults to the repository's default branch.
+    def pull_request_target_branch
+      ModuleSync.options[:pr_target_branch] || repository.default_branch
     end
 
     private

--- a/spec/unit/module_sync/repository_spec.rb
+++ b/spec/unit/module_sync/repository_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ModuleSync::Repository do
+  subject(:repository) do
+    described_class.new(directory: '/tmp/example', remote: 'https://github.com/example/repository.git')
+  end
+
+  let(:remote_branches) do
+    [
+      instance_double(Git::Branch, name: 'main'),
+      instance_double(Git::Branch, name: 'modulesync'),
+    ]
+  end
+  let(:branches) { instance_double(Git::Branches, remote: remote_branches) }
+  let(:log) { instance_double(Git::Log) }
+  let(:git) { instance_double(Git::Base, branches: branches, log: log) }
+
+  before do
+    repository.instance_variable_set(:@git, git)
+  end
+
+  it 'detects commits on a remote source branch that are missing from the target branch' do
+    allow(log).to receive(:between).with('origin/main', 'origin/modulesync').and_return(log)
+    allow(log).to receive(:execute).and_return([instance_double(Git::Object::Commit)])
+
+    expect(repository.remote_branch_ahead?('modulesync', 'main')).to be true
+  end
+
+  it 'rejects a source branch that does not exist remotely' do
+    remote_branches.pop
+
+    expect(repository.remote_branch_ahead?('modulesync', 'main')).to be false
+  end
+end

--- a/spec/unit/module_sync/source_code_spec.rb
+++ b/spec/unit/module_sync/source_code_spec.rb
@@ -7,9 +7,12 @@ describe ModuleSync::SourceCode do
     described_class.new('namespace/name', nil)
   end
 
+  let(:repository) { instance_double(ModuleSync::Repository, default_branch: 'main') }
+
   before do
     options = ModuleSync.config_defaults.merge({ git_base: 'file:///tmp/dummy' })
     ModuleSync.instance_variable_set :@options, options
+    allow(ModuleSync::Repository).to receive(:new).and_return(repository)
   end
 
   it 'has a repository namespace sets to "namespace"' do
@@ -18,5 +21,12 @@ describe ModuleSync::SourceCode do
 
   it 'has a repository name sets to "name"' do
     expect(subject.repository_name).to eq 'name'
+  end
+
+  it 'reports a remote source branch ahead of the PR target as ready' do
+    ModuleSync.options[:branch] = 'modulesync'
+    allow(repository).to receive(:remote_branch_ahead?).with('modulesync', 'main').and_return(true)
+
+    expect(subject.pull_request_branch_ready?).to be true
   end
 end

--- a/spec/unit/module_sync_spec.rb
+++ b/spec/unit/module_sync_spec.rb
@@ -12,5 +12,56 @@ describe ModuleSync do
       options = { managed_modules_conf: 'test_file.yml' }
       described_class.update(options)
     end
+
+    it 'validates PR credentials for every module before managing any module' do
+      allow(ModuleSync::Util).to receive(:parse_config).with('./config_defaults.yml').and_return({})
+      puppet_module = double
+      allow(described_class).to receive_messages(find_template_files: [], managed_modules: [puppet_module])
+
+      expect(puppet_module).to receive(:git_service).ordered
+      expect(described_class).to receive(:manage_module).with(puppet_module, [], {}).ordered
+
+      described_class.update(pr: true)
+    end
+
+    it 'does not manage modules when PR credentials are missing' do
+      allow(ModuleSync::Util).to receive(:parse_config).with('./config_defaults.yml').and_return({})
+      puppet_module = double
+      allow(described_class).to receive_messages(find_template_files: [], managed_modules: [puppet_module])
+      allow(puppet_module).to receive(:git_service)
+        .and_raise(ModuleSync::GitService::MissingCredentialsError, 'missing token')
+      expect(described_class).not_to receive(:manage_module)
+
+      expect { described_class.update(pr: true) }
+        .to raise_error(ModuleSync::GitService::MissingCredentialsError, 'missing token')
+    end
+  end
+
+  context '::manage_module' do
+    let(:repository) { instance_double(ModuleSync::Repository) }
+    let(:settings) { instance_double(ModuleSync::Settings) }
+    let(:puppet_module) do
+      instance_double(ModuleSync::PuppetModule,
+                      given_name: 'puppet-test',
+                      repository: repository,
+                      repository_name: 'puppet-test',
+                      repository_namespace: 'example')
+    end
+
+    before do
+      described_class.instance_variable_set(:@options, described_class.config_defaults.merge(pr: true))
+      allow(repository).to receive_messages(prepare_workspace: nil, submit_changes: false)
+      allow(puppet_module).to receive(:path).with(ModuleSync::MODULE_CONF_FILE).and_return('module-config.yml')
+      allow(ModuleSync::Util).to receive(:parse_config).with('module-config.yml').and_return({})
+      allow(ModuleSync::Settings).to receive(:new).and_return(settings)
+      allow(settings).to receive_messages(unmanaged_files: [], managed_files: [])
+      allow(puppet_module).to receive(:pull_request_branch_ready?).and_return(true)
+    end
+
+    it 'opens a requested PR for an unchanged branch that is ahead of its target' do
+      expect(puppet_module).to receive(:open_pull_request)
+
+      described_class.manage_module(puppet_module, [], {})
+    end
   end
 end


### PR DESCRIPTION
- if no token given, break, when a pr should be created
- if a branch was pushed, but no pr created yet, open one
- added unit tests for this
- locally tested the gem
  - it throws a ModuleSync::GitService::MissingCredentialsError when missing a token
  - it opens a pr if local and remote modulesync branch are available and ahead of target branch