### PR TITLE
fix: add guess_endpoint_from for github, similar to gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ or set them per repository in `managed_modules.yml`, using the `github` or
 
 For GitHub Enterprise and self-hosted GitLab instances you also need to set the
 `GITHUB_BASE_URL` or `GITLAB_BASE_URL` environment variables, or specify the
-`base_url` parameter in `modulesync.yml`:
+`base_url` parameter per repository in `managed_modules.yml`:
 
 ```yaml
 ---

--- a/lib/modulesync/git_service/github.rb
+++ b/lib/modulesync/git_service/github.rb
@@ -18,6 +18,13 @@ module ModuleSync
         @api = Octokit::Client.new(access_token: token)
       end
 
+      def self.guess_endpoint_from(remote:)
+        endpoint = super
+        return 'https://api.github.com' if endpoint == 'https://github.com'
+
+        endpoint
+      end
+
       private
 
       def _open_pull_request(repo_path:, namespace:, title:, message:, source_branch:, target_branch:, labels:, noop:)

--- a/spec/unit/module_sync/git_service/github_spec.rb
+++ b/spec/unit/module_sync/git_service/github_spec.rb
@@ -5,6 +5,18 @@ require 'spec_helper'
 require 'modulesync/git_service/github'
 
 describe ModuleSync::GitService::GitHub do
+  describe '.guess_endpoint_from' do
+    it 'uses the public GitHub API endpoint for a github.com remote' do
+      expect(described_class.guess_endpoint_from(remote: 'git@github.com:test/modulesync.git'))
+        .to eq('https://api.github.com')
+    end
+
+    it 'uses the remote hostname for a GitHub Enterprise remote' do
+      expect(described_class.guess_endpoint_from(remote: 'git@github.example.com:test/modulesync.git'))
+        .to eq('https://github.example.com')
+    end
+  end
+
   context '::open_pull_request' do
     before do
       @client = double


### PR DESCRIPTION
if you forget to export GITHUB_BASE_URL it now should return that for github it is https://api.github.com and do not fail anymore.

The priority is:
- Per-repository base_url in managed_modules.yml
- GITHUB_BASE_URL
- Automatic detection via guess_endpoint_from