### PR TITLE
feat: add best practices on how to version a gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ This gem is licensed under the Apache-2 license.
 ## Release information
 
 To make a new release, please do:
-* update the version in the gemspec file
+* update the version in `lib/modulesync/version.rb`
 * Install gems with `bundle install --with release --path .vendor`
 * generate the changelog with `bundle exec rake changelog`
 * Check if the new version matches the closed issues/PRs in the changelog

--- a/lib/modulesync.rb
+++ b/lib/modulesync.rb
@@ -11,6 +11,7 @@ require 'modulesync/puppet_module'
 require 'modulesync/renderer'
 require 'modulesync/settings'
 require 'modulesync/util'
+require 'modulesync/version'
 
 require 'monkey_patches'
 

--- a/lib/modulesync/version.rb
+++ b/lib/modulesync/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module ModuleSync
+  VERSION = '4.3.0'
+end

--- a/modulesync.gemspec
+++ b/modulesync.gemspec
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require_relative 'lib/modulesync/version'
 
 Gem::Specification.new do |spec|
   spec.name                  = 'modulesync'
-  spec.version               = '4.3.0'
+  spec.version               = ModuleSync::VERSION
   spec.authors               = ['Vox Pupuli']
   spec.email                 = ['voxpupuli@groups.io']
   spec.summary               = 'Puppet Module Synchronizer'


### PR DESCRIPTION
* A single source of truth for the version
* Available via ModuleSync::VERSION
* The gem code, CLI, and gemspec all use the same version
* Follows the standard structure of modern Ruby gems